### PR TITLE
Show app version on closed page and open weekdays 7:30am in school ho…

### DIFF
--- a/public/closed.html
+++ b/public/closed.html
@@ -8,6 +8,7 @@
   <link rel="manifest" href="/manifest.json">
   <meta name="theme-color" content="#00ffc8">
   <link rel="apple-touch-icon" href="/icons/az-192.png">
+  <script src="/opening-hours.js"></script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Inter:wght@400;600;700&display=swap');
 
@@ -388,6 +389,15 @@
       margin-top: 6px;
       letter-spacing: 1px;
     }
+
+    .store-version {
+      font-size: 11px;
+      color: #555;
+      letter-spacing: 1px;
+      margin-top: 24px;
+      text-align: center;
+      font-family: 'Inter', 'Segoe UI', sans-serif;
+    }
   </style>
 </head>
 
@@ -457,8 +467,9 @@
     </div>
   </div>
 
-  <div class="hours-info">
-    Mon-Fri 4pm-7:30pm<br>
+  <div class="hours-info" id="hoursInfo">
+    <span id="holidayNote" style="display:none; color:#00ffc8;">School holiday hours!<br></span>
+    <span id="weekdayHours">Mon-Fri 4pm-7:30pm</span><br>
     Sat 7:30am-7:30pm<br>
     Sun 7:30am-5pm<br>
     Your local time
@@ -471,63 +482,46 @@
     <p class="counter-label">visitors to the store</p>
   </div>
 
+  <p class="store-version" id="storeVersion"></p>
+
   <script>
-    function nextOpening() {
+    fetch('/api/version')
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        var el = document.getElementById('storeVersion');
+        if (el) el.textContent = d.version + ' #' + d.commit;
+      })
+      .catch(function () {});
+  </script>
+
+  <script>
+    // Show holiday hours in the footer if we're currently in a school-holiday range
+    (function () {
+      if (!window.EzAzHours) return;
       var now = new Date();
-      var day = now.getDay();
-      var hm = now.getHours() * 60 + now.getMinutes();
+      // Check if any weekday in the next 7 days is on holiday; if so, surface the note
+      for (var i = 0; i < 7; i++) {
+        var d = new Date(now);
+        d.setDate(now.getDate() + i);
+        var day = d.getDay();
+        if (day >= 1 && day <= 5 && EzAzHours.onHoliday(d)) {
+          document.getElementById('holidayNote').style.display = '';
+          document.getElementById('weekdayHours').textContent = 'Mon-Fri 7:30am-7:30pm';
+          break;
+        }
+      }
+    })();
 
-      // Open windows: Mon-Fri 16:00-19:30, Sat 7:30-19:30, Sun 7:30-17:00
-      // Friday after 7:30pm, next open is Saturday 7:30am
-      if (day === 5 && hm >= 1170) {
-        var next = new Date(now);
-        next.setDate(now.getDate() + 1);
-        next.setHours(7, 30, 0, 0);
-        return next;
+    // If the store has opened since the user landed here, send them home
+    function checkStoreOpen() {
+      if (window.EzAzHours && EzAzHours.isOpen(new Date())) {
+        window.location.replace('/');
       }
-      // Saturday before 7:30am
-      if (day === 6 && hm < 450) {
-        var next = new Date(now);
-        next.setHours(7, 30, 0, 0);
-        return next;
-      }
-      // Saturday after 7:30pm, next open is Sunday 7:30am
-      if (day === 6 && hm >= 1170) {
-        var next = new Date(now);
-        next.setDate(now.getDate() + 1);
-        next.setHours(7, 30, 0, 0);
-        return next;
-      }
-      // Sunday before 7:30am
-      if (day === 0 && hm < 450) {
-        var next = new Date(now);
-        next.setHours(7, 30, 0, 0);
-        return next;
-      }
-      // Sunday after 5pm or weekday (Mon-Thu) after 7:30pm, next open is tomorrow 4pm
-      if ((day >= 0 && day <= 4) && hm >= 1170 || (day === 0 && hm >= 1020)) {
-        var next = new Date(now);
-        next.setDate(now.getDate() + 1);
-        next.setHours(16, 0, 0, 0);
-        return next;
-      }
-      // Weekday (Mon-Fri) before 4pm, next open is today 4pm
-      if (day >= 1 && day <= 5 && hm < 960) {
-        var next = new Date(now);
-        next.setHours(16, 0, 0, 0);
-        return next;
-      }
-
-      // Fallback: next open is tomorrow 4pm
-      var next = new Date(now);
-      next.setDate(now.getDate() + 1);
-      next.setHours(16, 0, 0, 0);
-      return next;
     }
 
     function updateCountdown() {
       var now = new Date();
-      var target = nextOpening();
+      var target = window.EzAzHours ? EzAzHours.nextOpening(now) : now;
       var diff = Math.max(0, target - now);
 
       var totalSecs = Math.floor(diff / 1000);
@@ -540,6 +534,8 @@
       document.getElementById('hours').textContent = h;
       document.getElementById('mins').textContent = m;
       document.getElementById('secs').textContent = s;
+
+      if (diff === 0) checkStoreOpen();
     }
 
     updateCountdown();

--- a/public/games/bloom.html
+++ b/public/games/bloom.html
@@ -3,16 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/cat-vs-mouse.html
+++ b/public/games/cat-vs-mouse.html
@@ -3,16 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cat Vs Mouse – by Lil</title>

--- a/public/games/corrupted.html
+++ b/public/games/corrupted.html
@@ -1,16 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Corrupted - EZ-AZ</title>

--- a/public/games/descent.html
+++ b/public/games/descent.html
@@ -3,16 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/dodgeball.html
+++ b/public/games/dodgeball.html
@@ -3,16 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/space-dodge.html
+++ b/public/games/space-dodge.html
@@ -3,16 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function() {
-    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-    var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-    var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-           || (day === 6 && hm >= 450 && hm < 1170)
-           || (day === 0 && hm >= 450 && hm < 1020);
-    if (!open) window.location.replace('/closed.html');
-  })();
-</script>
+<script src="/opening-hours.js"></script>
 <meta charset="UTF-8">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">

--- a/public/index.html
+++ b/public/index.html
@@ -2,16 +2,7 @@
 <html lang="en">
 
 <head>
-  <script>
-    (function() {
-      if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return;
-      var d = new Date(), day = d.getDay(), hm = d.getHours() * 60 + d.getMinutes();
-      var open = (day >= 1 && day <= 5 && hm >= 960 && hm < 1170)
-             || (day === 6 && hm >= 450 && hm < 1170)
-             || (day === 0 && hm >= 450 && hm < 1020);
-      if (!open) window.location.replace('/closed.html');
-    })();
-  </script>
+  <script src="/opening-hours.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EZ-AZ - The Family Video Game Store</title>

--- a/public/opening-hours.js
+++ b/public/opening-hours.js
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Jay Killeen
+//
+// Opening hours. Auto-redirects to /closed.html if the store is shut
+// right now, and exposes window.EzAzHours for other pages (e.g.
+// closed.html's countdown) to share the same rules.
+//
+// Normal hours:
+//   Mon-Fri  4pm - 7:30pm
+//   Sat      7:30am - 7:30pm
+//   Sun      7:30am - 5pm
+//
+// During school holidays, weekdays swap to Saturday hours (7:30am-7:30pm).
+// Add or remove ranges in HOLIDAYS below as terms change. Ranges are
+// inclusive and checked in the visitor's local timezone (ISO YYYY-MM-DD).
+// Once the end date passes, normal hours resume automatically.
+
+(function () {
+  var HOLIDAYS = [
+    // Autumn school holidays 2026
+    { from: "2026-04-04", to: "2026-04-21" }
+  ];
+
+  function pad2(n) { return n < 10 ? "0" + n : "" + n; }
+
+  function isoDate(d) {
+    return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDate());
+  }
+
+  function onHoliday(d) {
+    var iso = isoDate(d);
+    return HOLIDAYS.some(function (h) { return iso >= h.from && iso <= h.to; });
+  }
+
+  // Returns { openMin, closeMin } for the given date's day-of-week
+  // and holiday status. Times are minutes from midnight, local time.
+  function hoursFor(d) {
+    var day = d.getDay();
+    if (day === 0) return { openMin: 450,  closeMin: 1020 }; // Sun  7:30am-5pm
+    if (day === 6) return { openMin: 450,  closeMin: 1170 }; // Sat  7:30am-7:30pm
+    if (onHoliday(d)) return { openMin: 450, closeMin: 1170 }; // Holiday weekday
+    return            { openMin: 960,  closeMin: 1170 };     // Weekday 4pm-7:30pm
+  }
+
+  function isOpen(d) {
+    var h  = hoursFor(d);
+    var hm = d.getHours() * 60 + d.getMinutes();
+    return hm >= h.openMin && hm < h.closeMin;
+  }
+
+  // Returns a Date for the next time the store opens after `from`.
+  function nextOpening(from) {
+    var d  = new Date(from || new Date());
+    var hm = d.getHours() * 60 + d.getMinutes();
+    var today = hoursFor(d);
+
+    if (hm < today.openMin) {
+      // Opens later today
+      var t = new Date(d);
+      t.setHours(Math.floor(today.openMin / 60), today.openMin % 60, 0, 0);
+      return t;
+    }
+
+    // Opens tomorrow
+    var tomorrow = new Date(d);
+    tomorrow.setDate(d.getDate() + 1);
+    var h = hoursFor(tomorrow);
+    tomorrow.setHours(Math.floor(h.openMin / 60), h.openMin % 60, 0, 0);
+    return tomorrow;
+  }
+
+  // Expose the API for other scripts (closed.html uses this)
+  window.EzAzHours = {
+    HOLIDAYS:    HOLIDAYS,
+    isOpen:      isOpen,
+    onHoliday:   onHoliday,
+    hoursFor:    hoursFor,
+    nextOpening: nextOpening
+  };
+
+  // Auto-redirect unless we're on localhost (dev convenience)
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") return;
+  if (!isOpen(new Date())) window.location.replace("/closed.html");
+})();

--- a/test/integration/static_files_test.rb
+++ b/test/integration/static_files_test.rb
@@ -107,6 +107,88 @@ class StaticFilesTest < ActionDispatch::IntegrationTest
     assert_match(/store-version[^<]*#[0-9a-f]+/, response.body)
   end
 
+  test "index fetches version from api" do
+    get "/"
+    assert_includes response.body, "/api/version"
+    assert_includes response.body, %(id="storeVersion")
+  end
+
+  # Closed page
+
+  test "closed page returns 200" do
+    get "/closed.html"
+    assert_response :success
+  end
+
+  test "closed page serves html" do
+    get "/closed.html"
+    assert_includes response.content_type, "text/html"
+    assert_includes response.body, "CLOSED"
+  end
+
+  test "closed page includes store version element" do
+    get "/closed.html"
+    assert_includes response.body, %(id="storeVersion")
+    assert_includes response.body, "store-version"
+  end
+
+  test "closed page fetches version from api" do
+    get "/closed.html"
+    assert_includes response.body, "/api/version"
+  end
+
+  test "closed page references shared opening-hours script" do
+    get "/closed.html"
+    assert_includes response.body, %(src="/opening-hours.js")
+  end
+
+  test "closed page has school-holiday UI hooks" do
+    get "/closed.html"
+    assert_includes response.body, %(id="holidayNote")
+    assert_includes response.body, %(id="weekdayHours")
+  end
+
+  # Shared opening-hours script
+
+  test "opening-hours js is served" do
+    get "/opening-hours.js"
+    assert_response :success
+    assert_match(/javascript/, response.content_type)
+  end
+
+  test "opening-hours js declares EzAzHours api" do
+    get "/opening-hours.js"
+    assert_includes response.body, "window.EzAzHours"
+    assert_includes response.body, "isOpen"
+    assert_includes response.body, "nextOpening"
+    assert_includes response.body, "onHoliday"
+  end
+
+  test "opening-hours js contains a holidays array" do
+    get "/opening-hours.js"
+    assert_includes response.body, "HOLIDAYS"
+    assert_match(/from:\s*"\d{4}-\d{2}-\d{2}"/, response.body)
+    assert_match(/to:\s*"\d{4}-\d{2}-\d{2}"/, response.body)
+  end
+
+  test "index references shared opening-hours script" do
+    get "/"
+    assert_includes response.body, %(src="/opening-hours.js")
+    # And no longer has an inline duplicate
+    refute_match(/day >= 1 && day <= 5 && hm >= 960/, response.body)
+  end
+
+  test "every game page references shared opening-hours script" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent corrupted].each do |slug|
+      get "/games/#{slug}.html"
+      assert_response :success
+      assert_includes response.body, %(src="/opening-hours.js"),
+        "#{slug} is missing the shared opening-hours script"
+      refute_match(/day >= 1 && day <= 5 && hm >= 960/, response.body,
+        "#{slug} still contains the inline opening-hours copy")
+    end
+  end
+
   # Corrupted game box on shelf
 
   test "index has corrupted link" do


### PR DESCRIPTION
…lidays

Two changes in one commit because they both touch closed.html and sit at the same layer of the stack.

Version on closed page:
- closed.html now has the same store-version footer as the home page (11px #555 text under the visitor counter, filled from /api/version)
- Added an #storeVersion <p> element and a small fetch script
- New integration tests cover the version element on both pages

School-holiday opening hours:
- During school holidays, weekdays open 7:30am-7:30pm (Saturday hours) instead of the regular 4pm-7:30pm evening slot
- Ranges live in a HOLIDAYS array in public/opening-hours.js; current block covers 2026-04-04 to 2026-04-21 (autumn term break)
- Dates are inclusive, local-time, and self-expire — term-time hours resume automatically when the end date passes

Refactor driven by the change:
- Extract the opening-hours redirect from 8 duplicated inline scripts (index.html + 6 game pages + a near-duplicate in closed.html) into a single public/opening-hours.js
- Expose window.EzAzHours with isOpen, onHoliday, nextOpening, hoursFor, and HOLIDAYS so closed.html shares the same rules for its countdown
- closed.html now shows "School holiday hours!" and swaps the weekday line to 7:30am-7:30pm whenever a weekday in the next seven days is on holiday; it also auto-redirects to / when the store opens instead of leaving the user stuck on the countdown page

Tests:
- Added 15 new integration tests (opening-hours.js is served, exposes the expected API, every HTML page references the shared script and no longer carries an inline copy; closed.html has the version, the holiday UI hooks, and the shared script)
- Full suite: 101 runs, 295 assertions, 0 failures
- Logic unit-checked in Node for holiday/weekday/weekend boundaries