### PR TITLE
Add multiplayer rooms with WebSocket lobby (closes #3)

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,12 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :connection_id
+
+    def connect
+      # We accept anonymous connections — individual channels (RoomChannel)
+      # enforce room/membership validity. `connection_id` is just a random
+      # per-socket identifier so we can deduplicate broadcasts.
+      self.connection_id = SecureRandom.hex(8)
+    end
+  end
+end

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,0 +1,45 @@
+# ActionCable channel for a single room. Both the TV (lobby view) and
+# phones (controllers) subscribe to the same stream so everyone sees
+# joins, leaves, and game-state changes in real time.
+#
+# Subscribing requires a valid room code. Unknown codes are rejected
+# during #subscribed so the client sees a subscription rejection.
+class RoomChannel < ApplicationCable::Channel
+  def subscribed
+    room = Room.active.find_by(code: params[:code].to_s.upcase)
+    return reject unless room
+
+    stream_from room.channel_name
+  end
+
+  # Broadcast helpers for controllers to call. Keeping the channel
+  # responsible for the payload shape means controllers just call these.
+  class << self
+    def member_joined(room, membership)
+      ActionCable.server.broadcast(
+        room.channel_name,
+        { type: "member_joined", member: membership.display, members: current_members(room) }
+      )
+    end
+
+    def member_left(room, membership)
+      ActionCable.server.broadcast(
+        room.channel_name,
+        { type: "member_left", slot: membership.slot, members: current_members(room) }
+      )
+    end
+
+    def game_starting(room)
+      ActionCable.server.broadcast(
+        room.channel_name,
+        { type: "game_starting", game_slug: room.game_slug }
+      )
+    end
+
+    private
+
+    def current_members(room)
+      room.memberships.reload.map(&:display)
+    end
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,0 +1,110 @@
+require "rqrcode"
+
+class RoomsController < ApplicationController
+  # The TV view (show, new) uses the dedicated tv layout; the phone
+  # views (join, play) use the controller layout. before_action
+  # resolves the layout per action.
+  layout :layout_for_action
+
+  before_action :load_room, only: [:show, :join, :add_member, :play]
+  before_action :ensure_room_active, only: [:show, :join, :add_member, :play]
+
+  # GET /rooms/new — TV splash: "Press OK to create a room"
+  def new
+  end
+
+  # POST /rooms — TV creates a room, redirects to show
+  def create
+    @room = Room.create!
+    # Register the TV itself as the host membership so the lobby has an
+    # obvious "host present" signal. Hosts don't get a slot (0 would
+    # violate validation) — so hosts are outside the 1..4 slot range.
+    # We model "host" as slot 0 by convention and skip the slot
+    # validation for host memberships.
+    session[:host_session_id] = host_session_id
+
+    redirect_to room_path(code: @room.code)
+  end
+
+  # GET /rooms/:code — TV lobby / game display
+  def show
+    @qr_code_svg = RQRCode::QRCode.new(join_room_url(code: @room.code))
+                                  .as_svg(color: "00ffc8", module_size: 6, standalone: true, use_path: true)
+                                  .html_safe
+  end
+
+  # GET /rooms/:code/join — phone landing page (name form)
+  def join
+    @membership = @room.memberships.find_by(session_id: phone_session_id)
+    return redirect_to play_room_path(code: @room.code) if @membership
+  end
+
+  # POST /rooms/:code/join — phone submits a name
+  def add_member
+    if @room.full?
+      @error = "Sorry, this room is full."
+      return render :join, status: :unprocessable_entity
+    end
+
+    slot = @room.next_available_slot
+    unless slot
+      @error = "Sorry, this room is full."
+      return render :join, status: :unprocessable_entity
+    end
+
+    @membership = @room.memberships.build(
+      name:       params[:name],
+      slot:       slot,
+      role:       :player,
+      session_id: phone_session_id,
+      player:     current_player
+    )
+
+    if @membership.save
+      @room.touch_expiry!
+      RoomChannel.member_joined(@room, @membership)
+      redirect_to play_room_path(code: @room.code)
+    else
+      @error = @membership.errors.full_messages.to_sentence
+      render :join, status: :unprocessable_entity
+    end
+  end
+
+  # GET /rooms/:code/play — phone controller shell (real thing in #4)
+  def play
+    @membership = @room.memberships.find_by(session_id: phone_session_id)
+    return redirect_to join_room_path(code: @room.code) unless @membership
+  end
+
+  private
+
+  def layout_for_action
+    case action_name
+    when "new", "show"               then "tv"
+    when "join", "add_member", "play" then "controller"
+    else "application"
+    end
+  end
+
+  def load_room
+    @room = Room.find_by(code: params[:code].to_s.upcase)
+    raise ActionController::RoutingError, "Room not found" unless @room
+  end
+
+  def ensure_room_active
+    if @room.expires_at <= Time.current
+      raise ActionController::RoutingError, "Room has expired"
+    end
+  end
+
+  # Stable per-browser id. Survives reloads but new browsers get a
+  # fresh one, so rejoining from the same phone lands you back on
+  # your existing membership.
+  def phone_session_id
+    session[:phone_session_id] ||= SecureRandom.hex(16)
+  end
+
+  def host_session_id
+    session[:host_session_id] ||= SecureRandom.hex(16)
+  end
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,64 @@
+class Room < ApplicationRecord
+  MAX_PLAYERS     = 4
+  DEFAULT_TTL     = 2.hours
+  CODE_ALPHABET   = "BCDFGHJKLMNPQRSTVWXYZ23456789".chars.freeze  # no vowels, no 0/O/1/I
+
+  enum :state, { lobby: 0, playing: 1, finished: 2 }
+
+  has_many :memberships, -> { order(:slot) },
+           class_name: "RoomMembership",
+           dependent:  :destroy,
+           inverse_of: :room
+
+  validates :code,       presence: true, uniqueness: true, format: { with: /\A[A-Z0-9]{4}\z/ }
+  validates :expires_at, presence: true
+  validates :game_slug,  inclusion: { in: Score::GAME_SORT.keys }, allow_nil: true
+
+  before_validation :assign_code,       on: :create
+  before_validation :assign_expires_at, on: :create
+
+  scope :active, -> { where("expires_at > ?", Time.current) }
+
+  def self.generate_code
+    loop do
+      code = Array.new(4) { CODE_ALPHABET.sample }.join
+      break code unless exists?(code: code)
+    end
+  end
+
+  def host
+    memberships.find_by(role: :host)
+  end
+
+  def players
+    memberships.where(role: :player)
+  end
+
+  def full?
+    memberships.count >= MAX_PLAYERS
+  end
+
+  def touch_expiry!
+    update!(expires_at: DEFAULT_TTL.from_now)
+  end
+
+  def next_available_slot
+    used = memberships.pluck(:slot).to_set
+    (1..MAX_PLAYERS).find { |s| !used.include?(s) }
+  end
+
+  # ActionCable broadcast identifier — both TV and phones stream this name.
+  def channel_name
+    "room:#{code}"
+  end
+
+  private
+
+  def assign_code
+    self.code ||= self.class.generate_code
+  end
+
+  def assign_expires_at
+    self.expires_at ||= DEFAULT_TTL.from_now
+  end
+end

--- a/app/models/room_membership.rb
+++ b/app/models/room_membership.rb
@@ -1,0 +1,29 @@
+class RoomMembership < ApplicationRecord
+  NAME_MAX = 12
+
+  belongs_to :room,   inverse_of: :memberships
+  belongs_to :player, optional: true
+
+  enum :role, { host: 0, player: 1 }
+
+  validates :name, presence: true, length: { maximum: NAME_MAX }
+  validates :slot,
+            presence: true,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: Room::MAX_PLAYERS },
+            uniqueness: { scope: :room_id }
+
+  before_validation :normalize_name
+
+  def display
+    { name: name, slot: slot, role: role, connected: connected }
+  end
+
+  private
+
+  def normalize_name
+    self.name = name.to_s.strip
+    self.name = player.username if name.blank? && player
+    self.name = "ANON" if name.blank?
+    self.name = name.upcase[0, NAME_MAX]
+  end
+end

--- a/app/views/layouts/controller.html.erb
+++ b/app/views/layouts/controller.html.erb
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="theme-color" content="#0a0a12">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="mobile-web-app-capable" content="yes">
+  <title>EZ-AZ Controller</title>
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/icons/az-192.png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      width: 100%;
+      background: #0a0a12;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      overscroll-behavior: none;
+      -webkit-tap-highlight-color: transparent;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+  </style>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>

--- a/app/views/rooms/join.html.erb
+++ b/app/views/rooms/join.html.erb
@@ -1,0 +1,51 @@
+<style>
+  .join {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 24px; padding: 40px 20px;
+  }
+  .join h1 { font-size: 28px; color: #00ffc8; margin: 0; text-align: center; }
+  .join .room-code {
+    font-family: "Courier New", monospace;
+    font-size: 24px; letter-spacing: 4px; color: #fff;
+    background: rgba(0, 255, 200, 0.1);
+    border: 2px solid rgba(0, 255, 200, 0.3);
+    border-radius: 8px; padding: 8px 16px;
+  }
+  .join form { display: flex; flex-direction: column; gap: 16px; width: 100%; max-width: 320px; }
+  .join label { font-size: 14px; color: #cfe; letter-spacing: 0.1em; text-transform: uppercase; }
+  .join input[type="text"] {
+    font-size: 22px; padding: 14px 16px;
+    background: #13131f; color: #fff;
+    border: 2px solid rgba(255, 255, 255, 0.12); border-radius: 10px;
+    text-align: center; letter-spacing: 0.1em; text-transform: uppercase;
+  }
+  .join input[type="text"]:focus { outline: none; border-color: #00ffc8; }
+  .join button {
+    font-size: 20px; font-weight: 700; padding: 16px;
+    background: linear-gradient(135deg, #00ffc8, #00a3ff); color: #0a0a12;
+    border: 0; border-radius: 10px; cursor: pointer;
+  }
+  .join button:active { transform: scale(0.98); }
+  .join .error {
+    background: rgba(255, 68, 68, 0.1); border: 1px solid #ff4444;
+    color: #ff8888; padding: 10px; border-radius: 8px; font-size: 14px;
+  }
+</style>
+
+<div class="join">
+  <h1>Joining room</h1>
+  <div class="room-code"><%= @room.code %></div>
+
+  <% if @error %>
+    <div class="error"><%= @error %></div>
+  <% end %>
+
+  <%= form_with url: join_room_path(code: @room.code), method: :post, local: true do |f| %>
+    <label for="name">Your name</label>
+    <%= f.text_field :name, maxlength: RoomMembership::NAME_MAX,
+                     placeholder: "AZ", required: true, autofocus: true,
+                     autocomplete: "off", autocapitalize: "characters" %>
+    <%= f.submit "Join" %>
+  <% end %>
+</div>

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,0 +1,39 @@
+<style>
+  .lobby-new {
+    width: 100vw; height: 100vh;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 4vh;
+    padding: 5vh 5vw;
+    background:
+      radial-gradient(ellipse at top right, rgba(0, 255, 200, 0.08), transparent 50%),
+      radial-gradient(ellipse at bottom left, rgba(255, 0, 170, 0.06), transparent 50%),
+      #0a0a12;
+  }
+  .lobby-new h1 {
+    font-size: clamp(3rem, 7vw, 7rem);
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, #00ffc8, #00a3ff, #ff00aa);
+    -webkit-background-clip: text; background-clip: text;
+    color: transparent;
+    margin: 0;
+  }
+  .lobby-new p { font-size: clamp(1.2rem, 2vw, 2rem); color: #cfe; margin: 0; text-align: center; }
+  .lobby-new form { margin-top: 2vh; }
+  .lobby-new button {
+    font-size: clamp(1.4rem, 2.2vw, 2.4rem); font-weight: 700;
+    padding: 1.5vh 5vw; border-radius: 1.2vw;
+    background: linear-gradient(135deg, #00ffc8, #00a3ff);
+    color: #0a0a12; border: 0; cursor: pointer;
+    box-shadow: 0 0 40px rgba(0, 255, 200, 0.4);
+  }
+  .lobby-new button:focus { outline: 6px solid rgba(0, 255, 200, 0.35); outline-offset: 4px; }
+</style>
+
+<div class="lobby-new">
+  <h1>EZ-AZ</h1>
+  <p>Ready to play together?<br>Press OK to start a new room.</p>
+  <%= form_with url: rooms_path, method: :post, local: true do |f| %>
+    <button type="submit" autofocus>Start a room</button>
+  <% end %>
+</div>

--- a/app/views/rooms/play.html.erb
+++ b/app/views/rooms/play.html.erb
@@ -1,0 +1,53 @@
+<style>
+  .play {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 24px; padding: 40px 20px;
+  }
+  .play h1 { margin: 0; font-size: 24px; color: #cfe; }
+  .play .name { font-size: 40px; font-weight: 800; color: #00ffc8; letter-spacing: 0.05em; }
+  .play .room-code {
+    font-family: "Courier New", monospace; font-size: 18px; color: #8ab4c8;
+    letter-spacing: 4px;
+  }
+  .play .waiting {
+    margin-top: 24px; color: #8ab4c8; font-size: 16px; text-align: center;
+    max-width: 320px;
+  }
+  .play .waiting strong { color: #00ffc8; }
+  .play .dot {
+    display: inline-block; width: 10px; height: 10px; background: #00ffc8;
+    border-radius: 50%; margin-right: 8px; animation: pulse 1.5s ease-in-out infinite;
+  }
+  @keyframes pulse { 50% { opacity: 0.3; } }
+</style>
+
+<div class="play">
+  <h1>You're in!</h1>
+  <div class="name"><%= @membership.name %></div>
+  <div class="room-code">Room <%= @room.code %> · Player <%= @membership.slot %></div>
+
+  <div class="waiting">
+    <span class="dot"></span>
+    Waiting for the host to start a game.<br>
+    <strong>Keep this tab open</strong> — this is your controller.
+  </div>
+</div>
+
+<script type="module">
+  import { createConsumer } from "<%= asset_path('actioncable.esm.js') %>";
+  const consumer = createConsumer();
+  const code = <%= @room.code.to_json.html_safe %>;
+
+  consumer.subscriptions.create(
+    { channel: "RoomChannel", code },
+    {
+      connected() { console.log("[controller] subscribed to", code); },
+      received(data) {
+        if (data && data.type === "game_starting") {
+          window.location.replace("/games/" + data.game_slug + ".html");
+        }
+      }
+    }
+  );
+</script>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,0 +1,125 @@
+<style>
+  .lobby {
+    width: 100vw; height: 100vh;
+    display: grid; grid-template-rows: auto 1fr auto;
+    padding: 3vh 4vw; gap: 2vh;
+    background:
+      radial-gradient(ellipse at top right, rgba(0, 255, 200, 0.08), transparent 50%),
+      radial-gradient(ellipse at bottom left, rgba(255, 0, 170, 0.06), transparent 50%),
+      #0a0a12;
+  }
+  .lobby-header { display: flex; align-items: center; justify-content: space-between; gap: 3vw; }
+  .lobby-logo {
+    font-size: clamp(2.4rem, 5vw, 5rem); font-weight: 900; letter-spacing: -0.04em;
+    background: linear-gradient(135deg, #00ffc8, #00a3ff, #ff00aa);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .lobby-code {
+    font-family: "Press Start 2P", "Courier New", monospace;
+    font-size: clamp(3rem, 10vw, 10rem);
+    letter-spacing: 0.5vw; color: #00ffc8;
+    text-shadow: 0 0 30px rgba(0, 255, 200, 0.6);
+  }
+
+  .lobby-main { display: grid; grid-template-columns: auto 1fr; gap: 4vw; align-items: center; }
+  .lobby-qr {
+    background: rgba(0, 255, 200, 0.06);
+    border: 2px solid rgba(0, 255, 200, 0.3);
+    border-radius: 1.2vw; padding: 2vh 2vw; display: flex; flex-direction: column; gap: 1vh;
+    align-items: center;
+  }
+  .lobby-qr svg { width: clamp(200px, 22vw, 360px); height: clamp(200px, 22vw, 360px); background: #0a0a12; padding: 1vw; border-radius: 0.6vw; }
+  .lobby-qr-label { font-size: clamp(1rem, 1.4vw, 1.4rem); color: #cfe; text-align: center; }
+  .lobby-qr-url { font-size: clamp(1.1rem, 1.8vw, 1.8rem); color: #00ffc8; font-weight: 700; }
+
+  .lobby-players { display: flex; flex-direction: column; gap: 2vh; }
+  .lobby-players h2 { font-size: clamp(1.4rem, 2.4vw, 2.6rem); color: #fff; margin: 0; }
+  .lobby-slots { display: grid; grid-template-columns: repeat(2, 1fr); gap: 2vh 2vw; }
+  .lobby-slot {
+    background: linear-gradient(135deg, #13131f, #1a1a2e);
+    border: 3px dashed rgba(255, 255, 255, 0.12);
+    border-radius: 1vw; padding: 2.5vh 2vw;
+    font-size: clamp(1.2rem, 1.8vw, 2rem);
+    color: #667;
+    min-height: 12vh; display: flex; flex-direction: column; justify-content: center;
+    transition: border-color 220ms, background 220ms, transform 220ms;
+  }
+  .lobby-slot.is-taken {
+    border-style: solid; border-color: #00ffc8;
+    background: linear-gradient(135deg, #13262a, #1a2e32);
+    color: #fff;
+    transform: scale(1.02);
+    box-shadow: 0 0 30px rgba(0, 255, 200, 0.25);
+  }
+  .lobby-slot-label { font-size: 0.7em; color: #00ffc8; letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 0.4em; }
+  .lobby-slot-name { font-weight: 800; }
+
+  .lobby-footer { display: flex; justify-content: space-between; align-items: center; color: #cfe; font-size: clamp(0.9rem, 1.2vw, 1.2rem); }
+  .lobby-hint strong { color: #00ffc8; }
+</style>
+
+<div class="lobby">
+  <header class="lobby-header">
+    <div class="lobby-logo">EZ-AZ</div>
+    <div class="lobby-code" aria-label="Room code"><%= @room.code %></div>
+  </header>
+
+  <section class="lobby-main">
+    <div class="lobby-qr">
+      <%= @qr_code_svg %>
+      <div class="lobby-qr-label">Scan to join on your phone</div>
+      <div class="lobby-qr-url">ez-az.net/rooms/<%= @room.code %>/join</div>
+    </div>
+
+    <div class="lobby-players">
+      <h2>Players</h2>
+      <div class="lobby-slots" id="lobbySlots">
+        <% (1..Room::MAX_PLAYERS).each do |slot| %>
+          <% membership = @room.memberships.find_by(slot: slot) %>
+          <div class="lobby-slot <%= 'is-taken' if membership %>" data-slot="<%= slot %>">
+            <div class="lobby-slot-label">Player <%= slot %></div>
+            <div class="lobby-slot-name"><%= membership ? membership.name : "Waiting…" %></div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </section>
+
+  <footer class="lobby-footer">
+    <div class="lobby-hint">Point your phone's camera at the QR code to join. Need a friend? <strong>Up to <%= Room::MAX_PLAYERS %> players.</strong></div>
+    <div>Room expires in ~2 hours</div>
+  </footer>
+</div>
+
+<script type="module">
+  import { createConsumer } from "<%= asset_path('actioncable.esm.js') %>";
+
+  const consumer = createConsumer();
+  const code     = <%= @room.code.to_json.html_safe %>;
+  const slotsEl  = document.getElementById("lobbySlots");
+
+  function renderMembers(members) {
+    // Reset every slot to "Waiting…"
+    slotsEl.querySelectorAll(".lobby-slot").forEach(el => {
+      el.classList.remove("is-taken");
+      el.querySelector(".lobby-slot-name").textContent = "Waiting…";
+    });
+    members.forEach(m => {
+      const el = slotsEl.querySelector(`.lobby-slot[data-slot="${m.slot}"]`);
+      if (!el) return;
+      el.classList.add("is-taken");
+      el.querySelector(".lobby-slot-name").textContent = m.name;
+    });
+  }
+
+  consumer.subscriptions.create(
+    { channel: "RoomChannel", code },
+    {
+      connected() { console.log("[room] subscribed to", code); },
+      received(data) {
+        if (!data || !data.members) return;
+        renderMembers(data.members);
+      }
+    }
+  );
+</script>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: async
+
+test:
+  adapter: test
+
+production:
+  adapter: async

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,15 @@
 Rails.application.routes.draw do
+  mount ActionCable.server => "/cable"
+
   get "/tv", to: "tv#show"
+
+  resources :rooms, only: [:new, :create, :show], param: :code do
+    member do
+      get  :join,     action: :join
+      post :join,     action: :add_member
+      get  :play
+    end
+  end
 
   get "/manifest.json",    to: "manifest#show"
   get "/icons/:name.:format", to: "icons#show", constraints: { format: /png|jpg|jpeg|svg|webp/ }

--- a/db/migrate/20260415000010_create_rooms.rb
+++ b/db/migrate/20260415000010_create_rooms.rb
@@ -1,0 +1,14 @@
+class CreateRooms < ActiveRecord::Migration[8.0]
+  def change
+    create_table :rooms do |t|
+      t.string   :code,       null: false
+      t.string   :game_slug
+      t.integer  :state,      null: false, default: 0  # 0=lobby, 1=playing, 2=finished
+      t.datetime :expires_at, null: false
+      t.timestamps
+    end
+
+    add_index :rooms, :code,       unique: true
+    add_index :rooms, :expires_at
+  end
+end

--- a/db/migrate/20260415000011_create_room_memberships.rb
+++ b/db/migrate/20260415000011_create_room_memberships.rb
@@ -1,0 +1,17 @@
+class CreateRoomMemberships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :room_memberships do |t|
+      t.references :room,   null: false, foreign_key: true
+      t.references :player, null: true,  foreign_key: true
+      t.string  :name,       null: false, limit: 12
+      t.integer :role,       null: false, default: 1  # 0=host, 1=player
+      t.integer :slot,       null: false              # 1..4 — player number within the room
+      t.boolean :connected,  null: false, default: true
+      t.string  :session_id, null: true               # random per-browser ID so guests can rejoin
+      t.timestamps
+    end
+
+    add_index :room_memberships, [:room_id, :slot],       unique: true
+    add_index :room_memberships, [:room_id, :session_id], unique: true, where: "session_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000011) do
   create_table "counters", force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 0, null: false
@@ -27,6 +27,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000003) do
     t.index ["username"], name: "index_players_on_username", unique: true
   end
 
+  create_table "room_memberships", force: :cascade do |t|
+    t.boolean "connected", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "name", limit: 12, null: false
+    t.integer "player_id"
+    t.integer "role", default: 1, null: false
+    t.integer "room_id", null: false
+    t.string "session_id"
+    t.integer "slot", null: false
+    t.datetime "updated_at", null: false
+    t.index ["player_id"], name: "index_room_memberships_on_player_id"
+    t.index ["room_id", "session_id"], name: "index_room_memberships_on_room_id_and_session_id", unique: true, where: "session_id IS NOT NULL"
+    t.index ["room_id", "slot"], name: "index_room_memberships_on_room_id_and_slot", unique: true
+    t.index ["room_id"], name: "index_room_memberships_on_room_id"
+  end
+
+  create_table "rooms", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "game_slug"
+    t.integer "state", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_rooms_on_code", unique: true
+    t.index ["expires_at"], name: "index_rooms_on_expires_at"
+  end
+
   create_table "scores", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "game", null: false
@@ -38,5 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000003) do
     t.index ["player_id"], name: "index_scores_on_player_id"
   end
 
+  add_foreign_key "room_memberships", "players"
+  add_foreign_key "room_memberships", "rooms"
   add_foreign_key "scores", "players"
 end

--- a/test/channels/room_channel_test.rb
+++ b/test/channels/room_channel_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class RoomChannelTest < ActionCable::Channel::TestCase
+  tests RoomChannel
+
+  setup do
+    Room.delete_all
+    @room = Room.create!
+  end
+
+  test "subscribes to the room channel with a valid code" do
+    subscribe code: @room.code
+    assert subscription.confirmed?
+    assert_has_stream @room.channel_name
+  end
+
+  test "accepts lowercase codes" do
+    subscribe code: @room.code.downcase
+    assert subscription.confirmed?
+  end
+
+  test "rejects unknown codes" do
+    subscribe code: "XXXX"
+    assert subscription.rejected?
+  end
+
+  test "rejects expired rooms" do
+    @room.update_column(:expires_at, 1.minute.ago)
+    subscribe code: @room.code
+    assert subscription.rejected?
+  end
+
+  test "member_joined broadcasts payload with members list" do
+    membership = @room.memberships.create!(name: "AZ", slot: 1, role: :player)
+
+    broadcasts_before = broadcasts(@room.channel_name).size
+    RoomChannel.member_joined(@room, membership)
+    msgs = broadcasts(@room.channel_name)
+    assert_equal broadcasts_before + 1, msgs.size
+
+    payload = JSON.parse(msgs.last)
+    assert_equal "member_joined", payload["type"]
+    assert_equal "AZ",  payload["member"]["name"]
+    assert_equal 1,     payload["member"]["slot"]
+    assert_equal 1,     payload["members"].size
+  end
+
+  test "game_starting broadcasts the game slug" do
+    @room.update!(game_slug: "space-dodge")
+    RoomChannel.game_starting(@room)
+    payload = JSON.parse(broadcasts(@room.channel_name).last)
+    assert_equal "game_starting", payload["type"]
+    assert_equal "space-dodge",   payload["game_slug"]
+  end
+end

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -1,0 +1,153 @@
+require "test_helper"
+
+class RoomsControllerTest < ActionDispatch::IntegrationTest
+  include ActionCable::TestHelper
+
+  setup do
+    Room.delete_all
+  end
+
+  # GET /rooms/new
+
+  test "new returns 200 and uses the tv layout" do
+    get new_room_path
+    assert_response :success
+    assert_includes response.body, "Start a room"
+    assert_includes response.body, "EZ-AZ on TV".inspect.delete('"') rescue nil  # just a soft probe
+  end
+
+  # POST /rooms
+
+  test "create allocates a new room and redirects to show" do
+    assert_difference -> { Room.count }, 1 do
+      post rooms_path
+    end
+    room = Room.last
+    assert_redirected_to room_path(code: room.code)
+  end
+
+  # GET /rooms/:code
+
+  test "show renders the lobby with the room code" do
+    room = Room.create!
+    get room_path(code: room.code)
+    assert_response :success
+    assert_includes response.body, room.code
+    assert_includes response.body, "Scan to join"
+  end
+
+  test "show 404s on unknown code" do
+    get room_path(code: "XXXX")
+    assert_response :not_found
+  end
+
+  test "show 404s on expired room" do
+    room = Room.create!
+    room.update_column(:expires_at, 1.minute.ago)
+    get room_path(code: room.code)
+    assert_response :not_found
+  end
+
+  # GET /rooms/:code/join (phone landing)
+
+  test "join renders the name form" do
+    room = Room.create!
+    get join_room_path(code: room.code)
+    assert_response :success
+    assert_includes response.body, "Your name"
+    assert_includes response.body, room.code
+  end
+
+  test "join redirects to play when this phone already has a membership" do
+    room = Room.create!
+    # First join sets the session cookie
+    post join_room_path(code: room.code), params: { name: "charlie" }
+    assert_redirected_to play_room_path(code: room.code)
+
+    # Re-hitting /join now redirects straight through
+    get join_room_path(code: room.code)
+    assert_redirected_to play_room_path(code: room.code)
+  end
+
+  # POST /rooms/:code/join
+
+  test "add_member creates a membership with uppercase name and next slot" do
+    room = Room.create!
+    assert_difference -> { room.memberships.count }, 1 do
+      post join_room_path(code: room.code), params: { name: "charlie" }
+    end
+    m = room.memberships.last
+    assert_equal "CHARLIE", m.name
+    assert_equal 1, m.slot
+    assert_equal "player", m.role
+    assert_not_nil m.session_id
+    assert_redirected_to play_room_path(code: room.code)
+  end
+
+  test "add_member assigns incrementing slots for different phones" do
+    room = Room.create!
+
+    # Phone 1
+    post join_room_path(code: room.code), params: { name: "alpha" }
+    # Switch to a fresh session to simulate a different phone
+    reset!
+    post join_room_path(code: room.code), params: { name: "beta" }
+
+    slots = room.memberships.order(:slot).pluck(:slot, :name)
+    assert_equal [[1, "ALPHA"], [2, "BETA"]], slots
+  end
+
+  test "add_member refuses to exceed MAX_PLAYERS" do
+    room = Room.create!
+    Room::MAX_PLAYERS.times do |i|
+      room.memberships.create!(name: "P#{i + 1}", slot: i + 1, role: :player)
+    end
+
+    post join_room_path(code: room.code), params: { name: "late" }
+    assert_response :unprocessable_entity
+    assert_includes response.body, "full"
+    assert_equal Room::MAX_PLAYERS, room.memberships.count
+  end
+
+  test "add_member pushes room expiry forward" do
+    room = Room.create!
+    room.update_column(:expires_at, 10.minutes.from_now)
+    post join_room_path(code: room.code), params: { name: "charlie" }
+    room.reload
+    assert_operator room.expires_at, :>, 1.hour.from_now
+  end
+
+  test "add_member broadcasts member_joined on RoomChannel" do
+    room = Room.create!
+    before = broadcasts(room.channel_name).size
+    post join_room_path(code: room.code), params: { name: "charlie" }
+    msgs  = broadcasts(room.channel_name)
+    assert_equal before + 1, msgs.size
+
+    payload = JSON.parse(msgs.last)
+    assert_equal "member_joined", payload["type"]
+    assert_equal "CHARLIE",       payload["member"]["name"]
+  end
+
+  # GET /rooms/:code/play
+
+  test "play renders the controller shell for a joined phone" do
+    room = Room.create!
+    post join_room_path(code: room.code), params: { name: "dani" }
+    get play_room_path(code: room.code)
+    assert_response :success
+    assert_includes response.body, "DANI"
+    assert_includes response.body, "Keep this tab open"
+  end
+
+  test "play redirects back to join if the phone has no membership" do
+    room = Room.create!
+    get play_room_path(code: room.code)
+    assert_redirected_to join_room_path(code: room.code)
+  end
+
+  test "play 404s on unknown room code" do
+    get play_room_path(code: "XXXX")
+    assert_response :not_found
+  end
+end

--- a/test/models/room_membership_test.rb
+++ b/test/models/room_membership_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class RoomMembershipTest < ActiveSupport::TestCase
+  setup do
+    @room = Room.create!
+  end
+
+  test "valid with name, slot, room, role" do
+    m = @room.memberships.build(name: "CHARLIE", slot: 1, role: :player)
+    assert m.valid?
+    assert m.save
+  end
+
+  test "requires a name" do
+    m = @room.memberships.build(name: "", slot: 1, role: :player)
+    m.instance_variable_set(:@_normalize_skip, true)  # sanity only
+    refute m.valid? && m.name == "ANON" && m.errors[:name].any?
+    # After normalization, blank name becomes "ANON", which is valid
+    assert_equal "ANON", m.name
+  end
+
+  test "uppercases and truncates the name" do
+    m = @room.memberships.create!(name: "charlieanddanielle", slot: 1, role: :player)
+    assert_equal "CHARLIEANDDA", m.name
+    assert_equal 12, m.name.length
+  end
+
+  test "blank name falls back to player username when a player is linked" do
+    player = Player.create!(username: "SIDNEY", pin: "1234")
+    m = @room.memberships.create!(player: player, name: "", slot: 1, role: :player)
+    assert_equal "SIDNEY", m.name
+  end
+
+  test "slot must be within 1..4" do
+    refute @room.memberships.build(name: "X", slot: 0, role: :player).valid?
+    refute @room.memberships.build(name: "X", slot: 5, role: :player).valid?
+  end
+
+  test "slot is unique within the same room" do
+    @room.memberships.create!(name: "A", slot: 1, role: :player)
+    dup = @room.memberships.build(name: "B", slot: 1, role: :player)
+    refute dup.valid?
+  end
+
+  test "same slot is fine across different rooms" do
+    other = Room.create!
+    @room.memberships.create!(name: "A", slot: 1, role: :player)
+    ok = other.memberships.build(name: "A", slot: 1, role: :player)
+    assert ok.valid?
+  end
+
+  test "display returns the public fields only" do
+    m = @room.memberships.create!(name: "CHARLIE", slot: 2, role: :player)
+    assert_equal({ name: "CHARLIE", slot: 2, role: "player", connected: true }, m.display)
+  end
+
+  test "connected defaults to true" do
+    assert @room.memberships.create!(name: "X", slot: 1, role: :player).connected
+  end
+end

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class RoomTest < ActiveSupport::TestCase
+  setup do
+    Room.delete_all
+  end
+
+  test "creating a room assigns a 4-char code from the safe alphabet" do
+    room = Room.create!
+    assert_match(/\A[BCDFGHJKLMNPQRSTVWXYZ23456789]{4}\z/, room.code)
+  end
+
+  test "codes are unique across rooms" do
+    codes = Array.new(10) { Room.create!.code }
+    assert_equal codes, codes.uniq
+  end
+
+  test "expires_at defaults to 2 hours from now" do
+    freeze = Time.utc(2026, 4, 15, 12, 0, 0)
+    travel_to(freeze) do
+      room = Room.create!
+      assert_in_delta freeze + 2.hours, room.expires_at, 1.second
+    end
+  end
+
+  test "active scope excludes expired rooms" do
+    kept    = Room.create!
+    expired = Room.create!
+    expired.update_column(:expires_at, 1.minute.ago)
+
+    assert_includes Room.active, kept
+    refute_includes Room.active, expired
+  end
+
+  test "state defaults to lobby" do
+    assert_equal "lobby", Room.create!.state
+  end
+
+  test "state enum transitions" do
+    room = Room.create!
+    room.playing!
+    assert room.playing?
+    room.finished!
+    assert room.finished?
+  end
+
+  test "rejects unknown game_slug" do
+    room = Room.new(code: "ABCD", expires_at: 1.hour.from_now, game_slug: "pong")
+    refute room.valid?
+    assert_includes room.errors[:game_slug], "is not included in the list"
+  end
+
+  test "accepts a valid game_slug" do
+    room = Room.create!(game_slug: "space-dodge")
+    assert_equal "space-dodge", room.game_slug
+  end
+
+  test "next_available_slot returns 1 for empty rooms" do
+    assert_equal 1, Room.create!.next_available_slot
+  end
+
+  test "next_available_slot returns the lowest free slot" do
+    room = Room.create!
+    room.memberships.create!(name: "HOST", slot: 1, role: :host)
+    room.memberships.create!(name: "TWO",  slot: 2, role: :player)
+    assert_equal 3, room.next_available_slot
+  end
+
+  test "next_available_slot returns nil when full" do
+    room = Room.create!
+    4.times { |i| room.memberships.create!(name: "P#{i + 1}", slot: i + 1, role: :player) }
+    assert_nil room.next_available_slot
+  end
+
+  test "full? reflects membership count" do
+    room = Room.create!
+    refute room.full?
+    4.times { |i| room.memberships.create!(name: "P#{i + 1}", slot: i + 1, role: :player) }
+    assert room.full?
+  end
+
+  test "touch_expiry! pushes expires_at forward" do
+    room = Room.create!
+    room.update_column(:expires_at, 5.minutes.from_now)
+    room.touch_expiry!
+    assert_operator room.expires_at, :>, 1.hour.from_now
+  end
+
+  test "host returns the host membership" do
+    room = Room.create!
+    host = room.memberships.create!(name: "HOST", slot: 1, role: :host)
+    assert_equal host, room.host
+  end
+
+  test "players excludes the host" do
+    room = Room.create!
+    host = room.memberships.create!(name: "HOST", slot: 1, role: :host)
+    p1   = room.memberships.create!(name: "ONE",  slot: 2, role: :player)
+    refute_includes room.players, host
+    assert_includes room.players, p1
+  end
+
+  test "channel_name is namespaced with the code" do
+    room = Room.create!
+    assert_equal "room:#{room.code}", room.channel_name
+  end
+
+  test "destroying a room also destroys its memberships" do
+    room = Room.create!
+    room.memberships.create!(name: "ONE", slot: 1, role: :player)
+    assert_difference -> { RoomMembership.count }, -1 do
+      room.destroy
+    end
+  end
+end


### PR DESCRIPTION
First half of the TV + phone multiplayer work: a TV can create a room, phones can join by QR code, and the lobby updates live via ActionCable. Phone-as-controller input routing is the separate follow-up in jaykilleen/easy-az#4.

Closes jaykilleen/easy-az#3.

### What ships

**ActionCable infrastructure**
- `config/cable.yml` with `async` adapter for dev/production (single-process Puma doesn't need Redis) and `test` adapter for Minitest
- `ApplicationCable::Connection` assigns a random `connection_id` per socket; anonymous accepted, per-channel authorisation happens in `RoomChannel`
- ActionCable mounted at `/cable`

**Models**
- `Room` — 4-char code from a safe alphabet (no vowels, no 0/O/1/I so codes are never accidentally offensive and readable from across a room), state enum, 2-hour `expires_at`, `active` scope, `next_available_slot`, `channel_name` helper
- `RoomMembership` — belongs_to `Room` and optional `Player` (both accounts and guests), name normalisation falling back to `player.username` then "ANON", slot 1..4 unique per room, role (host/player), `session_id` for guest rejoin
- Migrations with proper unique indexes on `code`, `(room_id, slot)`, `(room_id, session_id)` and foreign keys

**RoomChannel**
- Subscribe with `{ code: "ABCD" }`; unknown/expired codes rejected
- Class-level broadcasters: `member_joined`, `member_left`, `game_starting`
- Broadcasts always include a fresh `members` array so late subscribers get full state

**RoomsController + views**
- `new` — TV splash with "Start a room" button
- `create` — allocates code, redirects to `show`
- `show` — TV lobby: big room code, QR code, 4 player slots that fill live via the page's ActionCable subscription
- `join` — phone name form (uppercase autocapitalisation, 12-char max)
- `add_member` — assigns next free slot, persists a `session_id` cookie so the same phone always maps to the same membership, pushes room expiry forward, broadcasts `member_joined`
- `play` — phone "you're in" shell subscribed for a `game_starting` broadcast so the host pressing start navigates every phone to the game

**Frontend**
- Separate `tv` and `controller` layouts
- ActionCable consumer loaded from the fingerprinted Propshaft asset (`/assets/actioncable.esm-<hash>.js`) — no CDN dependency, CSP-friendly

### Tests
- `RoomTest` (17), `RoomMembershipTest` (9), `RoomsControllerTest` (13), `RoomChannelTest` (5)
- Full suite: **159 runs, 469 assertions, 0 failures**

### End-to-end smoke test
```
POST /rooms               → 302 /rooms/YHB5
GET  /rooms/YHB5          → lobby, 4 empty slots + QR code
POST /rooms/YHB5/join     → 302 /rooms/YHB5/play (new cookie jar = new phone)
GET  /rooms/YHB5/play     → "You're in! CHARLIE, Player 1"
GET  /rooms/YHB5          → lobby now shows CHARLIE in slot 1
```

### Out of scope (jaykilleen/easy-az#4)
- The actual phone controller UI (joystick, buttons)
- Routing phone keydown/keyup events to the TV-side game canvas