### PR TITLE
Phone-as-controller input routing via ActionCable

### DIFF
--- a/app/channels/controller_channel.rb
+++ b/app/channels/controller_channel.rb
@@ -1,0 +1,66 @@
+# Phones send inputs on this channel; the TV streams from the same room
+# input feed and dispatches them as keyboard events on its end.
+#
+# Subscription params:
+#   { code: "ABCD" }            -> TV subscription: streams only, does not send
+#   { code: "ABCD", slot: 1..4 } -> phone subscription: sends via #input
+#
+# Client payload for #input:
+#   { type: "keydown" | "keyup", input: "up" | "down" | "left" | "right"
+#                                      | "primary" | "secondary" | "pause" }
+#
+# Broadcast payload (to TV subscribers):
+#   { slot: 1, type: "keydown", input: "up" }
+class ControllerChannel < ApplicationCable::Channel
+  INPUT_STREAM_SUFFIX  = ":input"
+  ALLOWED_INPUT_TYPES  = %w[keydown keyup].freeze
+  ALLOWED_INPUT_NAMES  = %w[up down left right primary secondary pause].freeze
+
+  def subscribed
+    room = Room.active.find_by(code: params[:code].to_s.upcase)
+    return reject unless room
+
+    if phone?
+      return reject unless valid_slot?(room)
+      # Phones are senders. We don't stream_from anything — they only
+      # perform #input. This keeps phones from receiving echoes of their
+      # own events or seeing other players' inputs, which is wasteful
+      # bandwidth at best and risks bugs at worst.
+    else
+      stream_from input_stream(room)
+    end
+  end
+
+  def input(data)
+    room = Room.active.find_by(code: params[:code].to_s.upcase)
+    return unless room && phone? && valid_slot?(room)
+
+    type  = data["type"].to_s
+    name  = data["input"].to_s
+    return unless ALLOWED_INPUT_TYPES.include?(type)
+    return unless ALLOWED_INPUT_NAMES.include?(name)
+
+    ActionCable.server.broadcast(
+      input_stream(room),
+      { slot: slot, type: type, input: name }
+    )
+  end
+
+  private
+
+  def phone?
+    params[:slot].present?
+  end
+
+  def slot
+    params[:slot].to_i
+  end
+
+  def valid_slot?(room)
+    (1..Room::MAX_PLAYERS).cover?(slot) && room.memberships.exists?(slot: slot)
+  end
+
+  def input_stream(room)
+    "#{room.channel_name}#{INPUT_STREAM_SUFFIX}"
+  end
+end

--- a/app/controllers/room_input_controller.rb
+++ b/app/controllers/room_input_controller.rb
@@ -1,0 +1,11 @@
+# Serves the TV-side input router JS with the fingerprinted actioncable
+# URL baked in at request time. The static game HTML files reference
+# this at the stable URL /room-input.js and don't need to know about
+# Propshaft asset hashes.
+class RoomInputController < ApplicationController
+  def show
+    response.headers["Content-Type"] = "text/javascript; charset=utf-8"
+    response.headers["Cache-Control"] = "no-cache"
+    render template: "room_input/show", layout: false, formats: [:js]
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -6,8 +6,8 @@ class RoomsController < ApplicationController
   # resolves the layout per action.
   layout :layout_for_action
 
-  before_action :load_room, only: [:show, :join, :add_member, :play]
-  before_action :ensure_room_active, only: [:show, :join, :add_member, :play]
+  before_action :load_room,         only: [:show, :join, :add_member, :play, :start]
+  before_action :ensure_room_active, only: [:show, :join, :add_member, :play, :start]
 
   # GET /rooms/new — TV splash: "Press OK to create a room"
   def new
@@ -31,6 +31,7 @@ class RoomsController < ApplicationController
     @qr_code_svg = RQRCode::QRCode.new(join_room_url(code: @room.code))
                                   .as_svg(color: "00ffc8", module_size: 6, standalone: true, use_path: true)
                                   .html_safe
+    @games = Game.all
   end
 
   # GET /rooms/:code/join — phone landing page (name form)
@@ -76,12 +77,29 @@ class RoomsController < ApplicationController
     return redirect_to join_room_path(code: @room.code) unless @membership
   end
 
+  # POST /rooms/:code/start — host picks a game; broadcasts game_starting and
+  # redirects the TV to the game page with ?room=<code> so the game wires
+  # its key events to the ControllerChannel input stream.
+  def start
+    slug = params[:game_slug].to_s
+    unless Score::GAME_SORT.key?(slug)
+      @error = "Unknown game"
+      return redirect_to room_path(code: @room.code), alert: @error
+    end
+
+    @room.update!(game_slug: slug, state: :playing)
+    RoomChannel.game_starting(@room)
+
+    redirect_to "/games/#{slug}.html?room=#{@room.code}",
+                allow_other_host: false
+  end
+
   private
 
   def layout_for_action
     case action_name
-    when "new", "show"               then "tv"
-    when "join", "add_member", "play" then "controller"
+    when "new", "show", "start"                   then "tv"
+    when "join", "add_member", "play"             then "controller"
     else "application"
     end
   end

--- a/app/views/room_input/show.js.erb
+++ b/app/views/room_input/show.js.erb
@@ -1,0 +1,97 @@
+// TV-side input router for EZ-AZ multiplayer rooms.
+//
+// Served by RoomInputController so the fingerprinted actioncable asset
+// URL can be baked in. Games include <script src="/room-input.js">
+// and this file decides whether to activate based on ?room=<CODE> in
+// the URL — no other change to the game page is needed.
+
+(function () {
+  var params = new URLSearchParams(window.location.search);
+  var code   = params.get("room");
+  if (!code) return;
+
+  // --- Keymaps ---------------------------------------------------------
+
+  var ARROWS = {
+    up:        { key: "ArrowUp",    code: "ArrowUp",    keyCode: 38 },
+    down:      { key: "ArrowDown",  code: "ArrowDown",  keyCode: 40 },
+    left:      { key: "ArrowLeft",  code: "ArrowLeft",  keyCode: 37 },
+    right:     { key: "ArrowRight", code: "ArrowRight", keyCode: 39 },
+    primary:   { key: "Shift",      code: "ShiftRight", keyCode: 16, shift: true },
+    secondary: { key: " ",          code: "Space",      keyCode: 32 },
+    pause:     { key: "Escape",     code: "Escape",     keyCode: 27 }
+  };
+
+  var WASD = {
+    up:        { key: "w", code: "KeyW", keyCode: 87 },
+    down:      { key: "s", code: "KeyS", keyCode: 83 },
+    left:      { key: "a", code: "KeyA", keyCode: 65 },
+    right:     { key: "d", code: "KeyD", keyCode: 68 },
+    primary:   { key: "Shift",  code: "ShiftLeft", keyCode: 16, shift: true },
+    secondary: { key: "q",      code: "KeyQ",      keyCode: 81 },
+    pause:     { key: "Escape", code: "Escape",    keyCode: 27 }
+  };
+
+  // game slug -> slot -> map. A missing slot means that slot's inputs
+  // are ignored (e.g. in single-player games, only slot 1's phone drives).
+  var KEYMAPS = {
+    "space-dodge":  { 1: ARROWS, 2: WASD },
+    "dodgeball":    { 1: ARROWS, 2: WASD, 3: ARROWS, 4: WASD },
+    "bloom":        { 1: ARROWS },
+    "cat-vs-mouse": { 1: ARROWS },
+    "descent":      { 1: ARROWS },
+    "corrupted":    { 1: ARROWS, 2: WASD }
+  };
+
+  var match    = window.location.pathname.match(/\/games\/([a-z0-9-]+)\.html$/i);
+  var gameSlug = match ? match[1].toLowerCase() : null;
+
+  function mapFor(slot) {
+    var byGame = gameSlug && KEYMAPS[gameSlug];
+    if (byGame && byGame[slot]) return byGame[slot];
+    if (!byGame && slot === 1) return ARROWS;
+    return null;
+  }
+
+  function dispatch(type, entry) {
+    document.dispatchEvent(new KeyboardEvent(type, {
+      key:       entry.key,
+      code:      entry.code,
+      keyCode:   entry.keyCode,
+      which:     entry.keyCode,
+      shiftKey:  !!entry.shift,
+      bubbles:   true,
+      cancelable: true
+    }));
+  }
+
+  function handle(msg) {
+    if (!msg || typeof msg.slot !== "number") return;
+    if (msg.type !== "keydown" && msg.type !== "keyup") return;
+    var map = mapFor(msg.slot);
+    if (!map) return;
+    var entry = map[msg.input];
+    if (!entry) return;
+    dispatch(msg.type, entry);
+  }
+
+  // --- ActionCable bootstrap + subscription --------------------------
+
+  var ACTIONCABLE_URL = <%= asset_path("actioncable.esm.js").to_json.html_safe %>;
+
+  import(ACTIONCABLE_URL)
+    .then(function (mod) {
+      var consumer = mod.createConsumer();
+      consumer.subscriptions.create(
+        { channel: "ControllerChannel", code: code },
+        {
+          connected()    { console.log("[room-input] TV connected to room", code); },
+          disconnected() { console.log("[room-input] TV disconnected from", code); },
+          received(data) { handle(data); }
+        }
+      );
+    })
+    .catch(function (err) {
+      console.error("[room-input] could not load actioncable:", err);
+    });
+})();

--- a/app/views/rooms/play.html.erb
+++ b/app/views/rooms/play.html.erb
@@ -1,53 +1,257 @@
 <style>
   .play {
     flex: 1;
+    display: flex; flex-direction: column;
+    color: #fff;
+    min-height: 100vh;
+  }
+  .play-top {
+    padding: max(env(safe-area-inset-top), 12px) 20px 12px;
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-size: 14px; color: #8ab4c8; border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+  .play-top .name { color: #00ffc8; font-weight: 700; letter-spacing: 0.05em; font-size: 18px; }
+  .play-top .meta { font-family: "Courier New", monospace; letter-spacing: 2px; }
+
+  /* "Waiting for host" state */
+  .waiting {
+    flex: 1;
     display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 24px; padding: 40px 20px;
+    gap: 16px; padding: 20px; text-align: center;
   }
-  .play h1 { margin: 0; font-size: 24px; color: #cfe; }
-  .play .name { font-size: 40px; font-weight: 800; color: #00ffc8; letter-spacing: 0.05em; }
-  .play .room-code {
-    font-family: "Courier New", monospace; font-size: 18px; color: #8ab4c8;
-    letter-spacing: 4px;
-  }
-  .play .waiting {
-    margin-top: 24px; color: #8ab4c8; font-size: 16px; text-align: center;
-    max-width: 320px;
-  }
-  .play .waiting strong { color: #00ffc8; }
-  .play .dot {
+  .waiting .dot {
     display: inline-block; width: 10px; height: 10px; background: #00ffc8;
     border-radius: 50%; margin-right: 8px; animation: pulse 1.5s ease-in-out infinite;
   }
   @keyframes pulse { 50% { opacity: 0.3; } }
+  .waiting strong { color: #00ffc8; }
+
+  /* Controller active state */
+  .controller { flex: 1; display: none; position: relative; overflow: hidden; }
+  .controller.is-active { display: block; }
+
+  .joy-base {
+    position: absolute;
+    bottom: max(env(safe-area-inset-bottom), 32px);
+    left:   max(env(safe-area-inset-left),   32px);
+    width:  min(40vw, 200px);
+    height: min(40vw, 200px);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.06);
+    border: 2px solid rgba(0, 255, 200, 0.35);
+    touch-action: none; user-select: none; -webkit-user-select: none;
+  }
+  .joy-knob {
+    position: absolute; top: 50%; left: 50%;
+    width: 40%; height: 40%;
+    border-radius: 50%;
+    background: rgba(0, 255, 200, 0.3);
+    border: 2px solid rgba(0, 255, 200, 0.55);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    transition: background 100ms;
+  }
+  .joy-base.active .joy-knob { background: rgba(0, 255, 200, 0.55); }
+
+  .btn-area {
+    position: absolute;
+    bottom: max(env(safe-area-inset-bottom), 32px);
+    right:  max(env(safe-area-inset-right),  32px);
+    display: flex; flex-direction: column; gap: 16px; align-items: center;
+    touch-action: none; user-select: none; -webkit-user-select: none;
+  }
+  .ctrl-btn {
+    width: 84px; height: 84px; border-radius: 50%;
+    background: rgba(0, 255, 200, 0.1);
+    border: 2px solid rgba(0, 255, 200, 0.4);
+    color: #cfe; font-family: "Courier New", monospace; font-weight: 700; font-size: 14px;
+    display: flex; align-items: center; justify-content: center;
+    touch-action: none;
+  }
+  .ctrl-btn.active { background: rgba(0, 255, 200, 0.35); border-color: #00ffc8; color: #0a0a12; }
+
+  .pause-btn {
+    position: absolute;
+    top: max(env(safe-area-inset-top), 12px);
+    right: max(env(safe-area-inset-right), 12px);
+    width: 44px; height: 44px; border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.6);
+    display: flex; align-items: center; justify-content: center;
+    font-family: "Courier New", monospace; font-size: 18px;
+    touch-action: none;
+  }
+  .pause-btn.active { background: rgba(255, 255, 255, 0.2); }
+
+  .play-hint {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    color: rgba(255, 255, 255, 0.25); font-size: 14px; pointer-events: none;
+    text-align: center; line-height: 1.6;
+  }
 </style>
 
 <div class="play">
-  <h1>You're in!</h1>
-  <div class="name"><%= @membership.name %></div>
-  <div class="room-code">Room <%= @room.code %> · Player <%= @membership.slot %></div>
-
-  <div class="waiting">
-    <span class="dot"></span>
-    Waiting for the host to start a game.<br>
-    <strong>Keep this tab open</strong> — this is your controller.
+  <div class="play-top">
+    <div class="name"><%= @membership.name %></div>
+    <div class="meta">Room <%= @room.code %> · P<%= @membership.slot %></div>
   </div>
+
+  <!-- State A: waiting for the host to start a game -->
+  <section class="waiting" id="waiting" <%= "hidden".html_safe if @room.playing? %>>
+    <span><span class="dot"></span>Waiting for the host to start a game</span>
+    <div><strong>Keep this tab open</strong><br>it's your controller</div>
+  </section>
+
+  <!-- State B: active controller -->
+  <section class="controller <%= 'is-active' if @room.playing? %>" id="controller">
+    <div class="play-hint">Drag the joystick<br>Tap a button to act</div>
+
+    <div class="joy-base" id="joy">
+      <div class="joy-knob" id="joyKnob"></div>
+    </div>
+
+    <div class="btn-area" id="btns">
+      <div class="ctrl-btn" data-input="primary">FIRE</div>
+      <div class="ctrl-btn" data-input="secondary">JUMP</div>
+    </div>
+
+    <div class="pause-btn" id="pauseBtn" data-input="pause">||</div>
+  </section>
 </div>
 
 <script type="module">
   import { createConsumer } from "<%= asset_path('actioncable.esm.js') %>";
-  const consumer = createConsumer();
-  const code = <%= @room.code.to_json.html_safe %>;
 
+  var consumer  = createConsumer();
+  var code      = <%= @room.code.to_json.html_safe %>;
+  var slot      = <%= @membership.slot %>;
+  var waitingEl = document.getElementById("waiting");
+  var ctrlEl    = document.getElementById("controller");
+
+  // Subscribe to RoomChannel for lobby-level broadcasts (game_starting)
   consumer.subscriptions.create(
-    { channel: "RoomChannel", code },
+    { channel: "RoomChannel", code: code },
     {
-      connected() { console.log("[controller] subscribed to", code); },
       received(data) {
-        if (data && data.type === "game_starting") {
-          window.location.replace("/games/" + data.game_slug + ".html");
+        if (!data) return;
+        if (data.type === "game_starting") {
+          waitingEl.setAttribute("hidden", "");
+          ctrlEl.classList.add("is-active");
         }
       }
     }
   );
+
+  // Subscribe to ControllerChannel as a phone (with slot) to send inputs
+  var input = consumer.subscriptions.create(
+    { channel: "ControllerChannel", code: code, slot: slot },
+    {
+      connected()    { console.log("[controller] slot", slot, "connected"); },
+      disconnected() { console.log("[controller] slot", slot, "disconnected"); },
+      send(type, name) { this.perform("input", { type: type, input: name }); }
+    }
+  );
+
+  // --- Joystick --------------------------------------------------------
+
+  var joy     = document.getElementById("joy");
+  var joyKnob = document.getElementById("joyKnob");
+  var joyTouchId = null;
+  var center = { x: 0, y: 0 };
+  var radius = 0;
+  var dirs   = { up: false, down: false, left: false, right: false };
+
+  function updateJoy(tx, ty) {
+    var dx = tx - center.x, dy = ty - center.y;
+    var dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist > radius) { dx = dx / dist * radius; dy = dy / dist * radius; }
+    joyKnob.style.transform = "translate(calc(-50% + " + dx + "px), calc(-50% + " + dy + "px))";
+
+    var deadZone = radius * 0.2;
+    var newDirs = { up: false, down: false, left: false, right: false };
+    if (dist > deadZone) {
+      var angle = Math.atan2(dy, dx);
+      if (angle > -2.749 && angle < -0.393) newDirs.up = true;
+      if (angle > 0.393  && angle < 2.749)  newDirs.down = true;
+      if (angle > 1.963  || angle < -1.963) newDirs.left = true;
+      if (angle > -1.178 && angle < 1.178)  newDirs.right = true;
+    }
+    for (var d in dirs) {
+      if ( dirs[d] && !newDirs[d]) input.send("keyup",   d);
+      if (!dirs[d] &&  newDirs[d]) input.send("keydown", d);
+    }
+    dirs = newDirs;
+  }
+
+  function releaseJoy() {
+    joyKnob.style.transform = "translate(-50%, -50%)";
+    joy.classList.remove("active");
+    for (var d in dirs) { if (dirs[d]) input.send("keyup", d); }
+    dirs = { up: false, down: false, left: false, right: false };
+    joyTouchId = null;
+  }
+
+  joy.addEventListener("touchstart", function (e) {
+    e.preventDefault();
+    if (joyTouchId !== null) return;
+    var t = e.changedTouches[0];
+    joyTouchId = t.identifier;
+    var rect = joy.getBoundingClientRect();
+    center.x = rect.left + rect.width / 2;
+    center.y = rect.top  + rect.height / 2;
+    radius   = rect.width / 2;
+    joy.classList.add("active");
+    updateJoy(t.clientX, t.clientY);
+  });
+  joy.addEventListener("touchmove", function (e) {
+    e.preventDefault();
+    for (var i = 0; i < e.changedTouches.length; i++) {
+      if (e.changedTouches[i].identifier === joyTouchId) {
+        updateJoy(e.changedTouches[i].clientX, e.changedTouches[i].clientY);
+        break;
+      }
+    }
+  });
+  function joyEnd(e) {
+    for (var i = 0; i < e.changedTouches.length; i++) {
+      if (e.changedTouches[i].identifier === joyTouchId) { releaseJoy(); break; }
+    }
+  }
+  joy.addEventListener("touchend", joyEnd);
+  joy.addEventListener("touchcancel", joyEnd);
+
+  // --- Action + pause buttons -----------------------------------------
+
+  function bindButton(el) {
+    var name = el.getAttribute("data-input");
+    var touchId = null;
+    el.addEventListener("touchstart", function (e) {
+      e.preventDefault();
+      if (touchId !== null) return;
+      touchId = e.changedTouches[0].identifier;
+      el.classList.add("active");
+      input.send("keydown", name);
+      if (navigator.vibrate) navigator.vibrate(10);
+    });
+    function end(e) {
+      for (var i = 0; i < e.changedTouches.length; i++) {
+        if (e.changedTouches[i].identifier === touchId) {
+          el.classList.remove("active");
+          input.send("keyup", name);
+          touchId = null; break;
+        }
+      }
+    }
+    el.addEventListener("touchend", end);
+    el.addEventListener("touchcancel", end);
+  }
+
+  document.querySelectorAll("#btns .ctrl-btn").forEach(bindButton);
+  bindButton(document.getElementById("pauseBtn"));
+
+  // Release everything if the tab goes to background
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) releaseJoy();
+  });
 </script>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -85,11 +85,58 @@
     </div>
   </section>
 
+  <section class="lobby-games" aria-label="Choose a game">
+    <h2>Pick a game to start</h2>
+    <div class="lobby-game-row" id="lobbyGameRow">
+      <% @games.each_with_index do |game, i| %>
+        <%= form_with url: start_room_path(code: @room.code), method: :post, local: true, class: "lobby-game-form" do |f| %>
+          <%= f.hidden_field :game_slug, value: game[:slug] %>
+          <button type="submit" class="lobby-game" data-index="<%= i %>" tabindex="<%= i == 0 ? 0 : -1 %>">
+            <div class="lobby-game-icon"><%= game_icon_svg(game[:icon]) %></div>
+            <div class="lobby-game-title"><%= game[:title] %></div>
+            <div class="lobby-game-creators">by <%= game[:creators] %></div>
+          </button>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+
   <footer class="lobby-footer">
     <div class="lobby-hint">Point your phone's camera at the QR code to join. Need a friend? <strong>Up to <%= Room::MAX_PLAYERS %> players.</strong></div>
     <div>Room expires in ~2 hours</div>
   </footer>
 </div>
+
+<style>
+  .lobby-games { margin-top: 1.5vh; }
+  .lobby-games h2 { font-size: clamp(1.4rem, 2.2vw, 2.4rem); color: #fff; margin: 0 0 1.5vh; }
+  .lobby-game-row { display: flex; gap: 1.5vw; overflow-x: auto; padding: 1vh 0 2vh; scrollbar-width: none; }
+  .lobby-game-row::-webkit-scrollbar { display: none; }
+  .lobby-game-form { flex: 0 0 auto; }
+  .lobby-game {
+    flex: 0 0 auto;
+    background: linear-gradient(135deg, #13131f, #1a1a2e);
+    border: 3px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.8vw;
+    padding: 1.5vh 1.2vw;
+    width: clamp(180px, 16vw, 260px);
+    display: flex; flex-direction: column; gap: 0.8vh;
+    color: inherit; cursor: pointer;
+    transition: transform 180ms, border-color 180ms, box-shadow 180ms;
+    font: inherit; text-align: left;
+  }
+  .lobby-game:focus,
+  .lobby-game.is-focused {
+    outline: none;
+    transform: scale(1.06) translateY(-0.5vh);
+    border-color: #00ffc8;
+    box-shadow: 0 0 0 4px rgba(0, 255, 200, 0.25),
+                0 15px 40px rgba(0, 255, 200, 0.3);
+  }
+  .lobby-game-icon { width: 100%; aspect-ratio: 16 / 10; border-radius: 0.4vw; overflow: hidden; display: flex; align-items: center; justify-content: center; }
+  .lobby-game-title   { font-size: clamp(1rem, 1.4vw, 1.4rem); font-weight: 800; color: #fff; }
+  .lobby-game-creators{ font-size: clamp(0.8rem, 1vw, 1rem);  color: #00ffc8; font-weight: 600; }
+</style>
 
 <script type="module">
   import { createConsumer } from "<%= asset_path('actioncable.esm.js') %>";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,11 @@ Rails.application.routes.draw do
       get  :join,     action: :join
       post :join,     action: :add_member
       get  :play
+      post :start
     end
   end
 
+  get "/room-input.js",    to: "room_input#show", defaults: { format: :js }
   get "/manifest.json",    to: "manifest#show"
   get "/icons/:name.:format", to: "icons#show", constraints: { format: /png|jpg|jpeg|svg|webp/ }
 

--- a/public/games/bloom.html
+++ b/public/games/bloom.html
@@ -1328,5 +1328,6 @@ function showNewIdea() {
 }
 </script>
 <script src="/controls.js" data-buttons="sprint"></script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/public/games/cat-vs-mouse.html
+++ b/public/games/cat-vs-mouse.html
@@ -2378,5 +2378,6 @@ drawCat(350, 200, 1, 0, 0, false);
 mice.forEach(m => drawMouse(m));
 </script>
 <script src="/controls.js" data-buttons="none"></script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/public/games/corrupted.html
+++ b/public/games/corrupted.html
@@ -2638,5 +2638,6 @@ function gameLoop() {
 
 gameLoop();
 </script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/public/games/descent.html
+++ b/public/games/descent.html
@@ -1921,5 +1921,6 @@ fetchLeaderboard(false);
 gameLoop();
 </script>
 <script src="/controls.js" data-buttons="sprint"></script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/public/games/dodgeball.html
+++ b/public/games/dodgeball.html
@@ -1583,5 +1583,6 @@ function gameLoop() {
 // Start the loop
 gameLoop();
 </script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/public/games/space-dodge.html
+++ b/public/games/space-dodge.html
@@ -910,5 +910,6 @@ function draw() {
 
 function loop(){if(!started||paused)return;update();draw();if(players.some(p=>p.alive)||particles.length>0)requestAnimationFrame(loop);}
 </script>
+<script src="/room-input.js"></script>
 </body>
 </html>

--- a/test/channels/controller_channel_test.rb
+++ b/test/channels/controller_channel_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+class ControllerChannelTest < ActionCable::Channel::TestCase
+  tests ControllerChannel
+
+  setup do
+    Room.delete_all
+    @room       = Room.create!
+    @membership = @room.memberships.create!(name: "CHARLIE", slot: 1, role: :player)
+  end
+
+  # --- Subscribe behaviour --------------------------------------------
+
+  test "TV subscribes with code only and streams from the input stream" do
+    subscribe code: @room.code
+    assert subscription.confirmed?
+    assert_has_stream "#{@room.channel_name}:input"
+  end
+
+  test "phone subscribes with code + valid slot but does not stream" do
+    subscribe code: @room.code, slot: 1
+    assert subscription.confirmed?
+    assert_empty subscription.streams,
+      "phones should not stream_from the input stream (they only send)"
+  end
+
+  test "subscribe rejects unknown code" do
+    subscribe code: "XXXX", slot: 1
+    assert subscription.rejected?
+  end
+
+  test "subscribe rejects expired rooms" do
+    @room.update_column(:expires_at, 1.minute.ago)
+    subscribe code: @room.code, slot: 1
+    assert subscription.rejected?
+  end
+
+  test "phone subscribe rejects slot without a membership" do
+    subscribe code: @room.code, slot: 3
+    assert subscription.rejected?
+  end
+
+  test "phone subscribe rejects out-of-range slot" do
+    subscribe code: @room.code, slot: 9
+    assert subscription.rejected?
+  end
+
+  # --- Input routing ---------------------------------------------------
+
+  test "phone #input broadcasts a normalized payload on the input stream" do
+    subscribe code: @room.code, slot: 1
+
+    stream = "#{@room.channel_name}:input"
+    before = broadcasts(stream).size
+    perform :input, "type" => "keydown", "input" => "up"
+    msgs   = broadcasts(stream)
+    assert_equal before + 1, msgs.size
+
+    payload = JSON.parse(msgs.last)
+    assert_equal 1,          payload["slot"]
+    assert_equal "keydown",  payload["type"]
+    assert_equal "up",       payload["input"]
+  end
+
+  test "phone #input ignores unknown input names" do
+    subscribe code: @room.code, slot: 1
+    stream = "#{@room.channel_name}:input"
+    before = broadcasts(stream).size
+    perform :input, "type" => "keydown", "input" => "hack"
+    assert_equal before, broadcasts(stream).size
+  end
+
+  test "phone #input ignores unknown event types" do
+    subscribe code: @room.code, slot: 1
+    stream = "#{@room.channel_name}:input"
+    before = broadcasts(stream).size
+    perform :input, "type" => "mousedown", "input" => "up"
+    assert_equal before, broadcasts(stream).size
+  end
+
+  test "TV subscription cannot send inputs (no slot => no broadcast)" do
+    subscribe code: @room.code
+    stream = "#{@room.channel_name}:input"
+    before = broadcasts(stream).size
+    perform :input, "type" => "keydown", "input" => "up"
+    assert_equal before, broadcasts(stream).size
+  end
+
+  test "inputs are accepted for every occupied slot" do
+    @room.memberships.create!(name: "DANI", slot: 2, role: :player)
+    stream = "#{@room.channel_name}:input"
+
+    subscribe code: @room.code, slot: 1
+    perform :input, "type" => "keydown", "input" => "up"
+    payload = JSON.parse(broadcasts(stream).last)
+    assert_equal 1, payload["slot"]
+
+    subscribe code: @room.code, slot: 2
+    perform :input, "type" => "keydown", "input" => "left"
+    payload = JSON.parse(broadcasts(stream).last)
+    assert_equal 2,      payload["slot"]
+    assert_equal "left", payload["input"]
+  end
+end

--- a/test/controllers/room_input_controller_test.rb
+++ b/test/controllers/room_input_controller_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class RoomInputControllerTest < ActionDispatch::IntegrationTest
+  test "GET /room-input.js returns JS content-type" do
+    get "/room-input.js"
+    assert_response :success
+    assert_includes response.content_type, "javascript"
+  end
+
+  test "response bakes in the fingerprinted actioncable asset URL" do
+    get "/room-input.js"
+    assert_match %r{/assets/actioncable\.esm-[0-9a-f]+\.js}, response.body
+  end
+
+  test "response contains the per-game keymaps" do
+    get "/room-input.js"
+    %w[space-dodge dodgeball bloom cat-vs-mouse descent corrupted].each do |slug|
+      assert_includes response.body, slug, "missing keymap for #{slug}"
+    end
+  end
+
+  test "response subscribes to ControllerChannel" do
+    get "/room-input.js"
+    assert_includes response.body, "ControllerChannel"
+    assert_includes response.body, "handle"
+    assert_includes response.body, "KeyboardEvent"
+  end
+
+  test "response aborts early when no ?room= param is present" do
+    get "/room-input.js"
+    assert_includes response.body, 'params.get("room")'
+    assert_includes response.body, "if (!code) return"
+  end
+
+  test "no-cache so updates ship immediately" do
+    get "/room-input.js"
+    assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+end

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -150,4 +150,46 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     get play_room_path(code: "XXXX")
     assert_response :not_found
   end
+
+  # POST /rooms/:code/start
+
+  test "start persists game_slug and flips state to playing" do
+    room = Room.create!
+    post start_room_path(code: room.code), params: { game_slug: "space-dodge" }
+    room.reload
+    assert_equal "space-dodge", room.game_slug
+    assert_equal "playing",     room.state
+  end
+
+  test "start redirects the TV to the game page with ?room=<code>" do
+    room = Room.create!
+    post start_room_path(code: room.code), params: { game_slug: "bloom" }
+    assert_redirected_to "/games/bloom.html?room=#{room.code}"
+  end
+
+  test "start broadcasts game_starting on RoomChannel" do
+    room = Room.create!
+    before = broadcasts(room.channel_name).size
+    post start_room_path(code: room.code), params: { game_slug: "descent" }
+    msgs = broadcasts(room.channel_name)
+    assert_equal before + 1, msgs.size
+
+    payload = JSON.parse(msgs.last)
+    assert_equal "game_starting", payload["type"]
+    assert_equal "descent",       payload["game_slug"]
+  end
+
+  test "start rejects unknown game slugs" do
+    room = Room.create!
+    post start_room_path(code: room.code), params: { game_slug: "pong" }
+    assert_redirected_to room_path(code: room.code)
+    room.reload
+    assert_nil room.game_slug
+    assert_equal "lobby", room.state
+  end
+
+  test "start 404s on unknown room code" do
+    post start_room_path(code: "XXXX"), params: { game_slug: "bloom" }
+    assert_response :not_found
+  end
 end

--- a/test/integration/static_files_test.rb
+++ b/test/integration/static_files_test.rb
@@ -216,6 +216,14 @@ class StaticFilesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "every game page references the room-input router" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent corrupted].each do |slug|
+      get "/games/#{slug}.html"
+      assert_includes response.body, %(src="/room-input.js"),
+        "#{slug} is missing the room-input.js script"
+    end
+  end
+
   # Corrupted game box on shelf
 
   test "index has corrupted link" do


### PR DESCRIPTION
With jaykilleen/easy-az#3's room lobby shipped, this wires phone touch inputs through to the TV's game canvas so families can actually play. Closes jaykilleen/easy-az#4.

**No game code is modified beyond a one-line `<script>` include.** The router dispatches `KeyboardEvent`s the games already understand.

### How it works

```
  Phone                  Server                 TV (game page)
  ─────                  ──────                 ──────────────
  touch joystick
      ↓
  ControllerChannel
    subscribe {code, slot} ─→
    perform :input         ─→ validate + broadcast
                              → room:ABCD:input
                              → slot + type + input
                                                         ←─ stream_from
                                                             ↓
                                                         /room-input.js
                                                             ↓
                                                         KeyboardEvent
                                                         (ArrowUp, KeyW, …)
                                                             ↓
                                                         game already
                                                         listens for it
```

### What ships

**`ControllerChannel`**
- `{code}` subscription → TV role, streams from `room:<code>:input`
- `{code, slot}` subscription → phone role, no stream, accepts `#input`
- `#input` validates `type ∈ {keydown, keyup}` and `input ∈ {up, down, left, right, primary, secondary, pause}` before broadcasting
- Rejects unknown/expired rooms, out-of-range slots, and unoccupied slots

**`RoomsController#start`** (POST `/rooms/:code/start`)
- Host posts `game_slug` from the lobby's game picker
- Persists `game_slug`, flips state to `:playing`, broadcasts `game_starting`
- Redirects the TV to `/games/<slug>.html?room=<code>`

**`/room-input.js`** (Rails-served via `RoomInputController`)
- Self-activates only when `?room=` is present — single-device play unaffected
- Per-game, per-slot keymaps:
  - `space-dodge`, `corrupted` → slot 1 arrows / slot 2 WASD
  - `dodgeball` → slots 1–4 alternate arrows / WASD
  - `bloom`, `cat-vs-mouse`, `descent` → slot 1 arrows (single-player)
- Served via Rails so the fingerprinted `/assets/actioncable.esm-<hash>.js` URL can be interpolated — static game HTML can't use `asset_path` directly

**Phone controller UI** (`rooms/play.html.erb`)
- Real joystick + FIRE + JUMP buttons and a pause button
- `env(safe-area-inset-*)` on all sides — addresses part of jaykilleen/easy-az#12's audit
- Haptic feedback via `navigator.vibrate`
- Transitions from "waiting" → "controller" on `game_starting` broadcast

**TV lobby game picker** (`rooms/show.html.erb`)
- Horizontally-scrollable row of `Game.all` under the QR code
- Each is a plain `<form>` posting `game_slug` to `/rooms/:code/start` — click-to-launch, no extra JS

**Game HTML**
- One `<script src="/room-input.js"></script>` added to each of the 6 games

### Tests

- `ControllerChannelTest` — TV/phone roles, rejections, `#input` broadcast shape, multi-slot routing (11)
- `RoomInputControllerTest` — served as JS, fingerprinted URL baked in, contains every keymap, aborts on missing `?room=`, no-cache (6)
- `RoomsController#start` tests — persists slug/state, redirects with `?room=`, broadcasts `game_starting`, rejects bogus slugs, 404s on unknown rooms (5)
- `static_files_test` — every game page references `/room-input.js` (1)
- **Full suite: 182 runs, 542 assertions, 0 failures**

### End-to-end smoke (curl)

```
POST /rooms                          → /rooms/W7WF
GET  /rooms/W7WF                     → lobby with game-picker buttons
POST /rooms/W7WF/start game=bloom    → 302 /games/bloom.html?room=W7WF
GET  /room-input.js                  → bakes /assets/actioncable.esm-<hash>.js
All six game HTMLs include src="/room-input.js"
```

### Out of scope (planned in jaykilleen/easy-az#11, informed by jaykilleen/easy-az#12)

- The shared `game-viewport` helper and canvas-scaling refactor for the 5 games with fixed-700 canvases
- Game-specific controller schemes for Corrupted (look + fire) and Dodgeball's 4-player layout beyond the generic arrows+WASD assignment