### PR TITLE
Fix login "Could not reach server" error by always returning JSON from /api/*

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,51 @@
+# Base class for every JSON API controller.
+#
+# Inheriting from this guarantees that any uncaught exception is returned
+# as a JSON body (instead of Rails' default public/500.html) so that the
+# client's `fetch(...).then(r => r.json())` never blows up and gets back
+# a useful error payload. The alternative — HTML error pages — is exactly
+# what caused the generic "Could not reach server" messages on login
+# (see issue #16): the client couldn't parse the HTML 500 as JSON, so
+# `.catch()` fired with a misleading message.
+module Api
+  class BaseController < ApplicationController
+    # rescue_from matches the LAST-registered handler first, so the
+    # generic StandardError fallback goes first and more-specific
+    # handlers follow and override it.
+
+    rescue_from StandardError do |e|
+      Rails.logger.error("[api] #{e.class}: #{e.message}")
+      e.backtrace&.first(10)&.each { |l| Rails.logger.error("  #{l}") }
+
+      message = if Rails.env.production?
+        "Something went wrong on our end. Please try again."
+      else
+        "#{e.class}: #{e.message}"
+      end
+      render_api_error(:internal_server_error, message, e)
+    end
+
+    rescue_from ActionController::ParameterMissing do |e|
+      render_api_error(:bad_request, "Missing parameter: #{e.param}", e)
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      render_api_error(:unprocessable_entity, e.record.errors.full_messages.first || "Invalid request", e)
+    end
+
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      render_api_error(:not_found, "Not found", e)
+    end
+
+    private
+
+    def render_api_error(status, message, exception = nil)
+      payload = { error: message }
+      if exception && !Rails.env.production?
+        payload[:exception] = exception.class.name
+        payload[:backtrace] = exception.backtrace&.first(5)
+      end
+      render json: payload, status: status
+    end
+  end
+end

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class PlayersController < ApplicationController
+  class PlayersController < BaseController
     # POST /api/players
     # Body: { username, pin }
     def create

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class ScoresController < ApplicationController
+  class ScoresController < BaseController
     def index
       game = params[:game]
 

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class SessionsController < ApplicationController
+  class SessionsController < BaseController
     # GET /api/sessions
     # Returns current logged-in player or null
     def show

--- a/app/controllers/api/version_controller.rb
+++ b/app/controllers/api/version_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class VersionController < ApplicationController
+  class VersionController < BaseController
     def show
       render json: { version: EzAz::Version::STRING, commit: EzAz::Version::COMMIT }
     end

--- a/public/index.html
+++ b/public/index.html
@@ -2229,6 +2229,32 @@
       var pinConfirmInput = document.getElementById('authPinConfirm');
       var whoamiEl        = document.getElementById('authWhoami');
 
+      // Shared fetch helper that returns { ok, status, data } and surfaces
+      // useful errors even when the server blows up. The old code used
+      // `r.json()` directly, which threw on HTML error pages and fell
+      // into the catch block with a misleading "could not reach server"
+      // message (see issue #16).
+      function apiFetch(url, options) {
+        return fetch(url, options).then(function (r) {
+          return r.text().then(function (text) {
+            var data = null;
+            if (text) {
+              try { data = JSON.parse(text); }
+              catch (e) {
+                var snippet = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120);
+                var label = 'Server error (HTTP ' + r.status + ')';
+                if (snippet) label += ': ' + snippet;
+                var err = new Error(label);
+                err.status = r.status;
+                err.body   = text;
+                throw err;
+              }
+            }
+            return { ok: r.ok, status: r.status, data: data };
+          });
+        });
+      }
+
       function showStep(name) {
         [stepUsername, stepLogin, stepRegister, stepLoggedIn].forEach(function (el) {
           el.style.display = 'none';
@@ -2323,27 +2349,27 @@
         if (pin.length !== 4) { setError('PIN must be 4 digits.'); return; }
         setError('');
         document.getElementById('authLoginBtn').disabled = true;
-        fetch('/api/session', {
+        apiFetch('/api/session', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
           body: JSON.stringify({ username: username, pin: pin })
         })
-          .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
           .then(function (res) {
             document.getElementById('authLoginBtn').disabled = false;
             if (res.ok) {
-              currentPlayer = res.d.player;
+              currentPlayer = res.data.player;
               updateBtn();
               closeModal();
             } else {
-              setError(res.d.error || 'Login failed.');
+              setError((res.data && res.data.error) || 'Login failed (HTTP ' + res.status + ').');
               pinInput.value = '';
               pinInput.focus();
             }
           })
-          .catch(function () {
+          .catch(function (err) {
             document.getElementById('authLoginBtn').disabled = false;
-            setError('Could not reach the server. Try again.');
+            console.error('[login]', err);
+            setError(err && err.message ? err.message : 'Could not reach the server. Try again.');
           });
       }
 
@@ -2359,25 +2385,25 @@
         if (pin !== pinConfirm) { setError('PINs do not match.'); pinConfirmInput.focus(); return; }
         setError('');
         document.getElementById('authRegisterBtn').disabled = true;
-        fetch('/api/players', {
+        apiFetch('/api/players', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
           body: JSON.stringify({ username: username, pin: pin })
         })
-          .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
           .then(function (res) {
             document.getElementById('authRegisterBtn').disabled = false;
             if (res.ok) {
-              currentPlayer = res.d;
+              currentPlayer = res.data;
               updateBtn();
               closeModal();
             } else {
-              setError(res.d.error || 'Could not create account.');
+              setError((res.data && res.data.error) || 'Could not create account (HTTP ' + res.status + ').');
             }
           })
-          .catch(function () {
+          .catch(function (err) {
             document.getElementById('authRegisterBtn').disabled = false;
-            setError('Could not reach the server. Try again.');
+            console.error('[register]', err);
+            setError(err && err.message ? err.message : 'Could not reach the server. Try again.');
           });
       }
 

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+# Exercises Api::BaseController's shared behaviour (JSON-for-everything
+# error handling). We use a throwaway controller mounted at a private
+# test-only route so we can deliberately raise exceptions without
+# teaching the real API endpoints tricks they don't need.
+class Api::BaseControllerTest < ActionDispatch::IntegrationTest
+  # Test-only controller subclasses Api::BaseController and lets each
+  # action raise a specific kind of error so we can assert the
+  # JSON-ification works end-to-end.
+  class ExplodingController < Api::BaseController
+    def boom
+      raise "kaboom"
+    end
+
+    def missing
+      raise ActiveRecord::RecordNotFound, "nope"
+    end
+
+    def invalid
+      # Build an invalid record and use save! so RecordInvalid is raised
+      Player.new(username: "").tap { |p| p.save! }
+    end
+  end
+
+  setup do
+    @routes = Rails.application.routes.dup
+    @routes.disable_clear_and_finalize = true
+    @routes.draw do
+      get "/__exploding/boom",    to: "api/base_controller_test/exploding#boom"
+      get "/__exploding/missing", to: "api/base_controller_test/exploding#missing"
+      get "/__exploding/invalid", to: "api/base_controller_test/exploding#invalid"
+    end
+    @original_routes = Rails.application.routes
+    Rails.application.instance_variable_set(:@routes, @routes)
+  end
+
+  teardown do
+    Rails.application.instance_variable_set(:@routes, @original_routes)
+  end
+
+  test "unhandled exception returns JSON with 500 status" do
+    get "/__exploding/boom"
+    assert_response :internal_server_error
+    assert_includes response.content_type, "application/json"
+    body = JSON.parse(response.body)
+    assert body.key?("error"),
+      "body should include an 'error' key (got #{body.inspect})"
+  end
+
+  test "RecordNotFound returns JSON 404" do
+    get "/__exploding/missing"
+    assert_response :not_found
+    body = JSON.parse(response.body)
+    assert_equal "Not found", body["error"]
+  end
+
+  test "RecordInvalid returns JSON 422 with the validation message" do
+    get "/__exploding/invalid"
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert body["error"].present?,
+      "validation message should surface (got #{body.inspect})"
+  end
+
+  test "non-production environments include debug info for easier triage" do
+    get "/__exploding/boom"
+    body = JSON.parse(response.body)
+    assert_equal "RuntimeError", body["exception"]
+    assert_kind_of Array, body["backtrace"]
+  end
+end


### PR DESCRIPTION
Closes jaykilleen/easy-az#16.

### Root cause

When a Rails request inside `/api/*` hits an unhandled exception, Rails serves the static `public/500.html` (HTML) as the response body. The client's login code then calls `r.json()` on that HTML, which throws and drops into `.catch()`. `.catch()` had a hard-coded **"Could not reach the server"** message that misrepresented every possible failure mode as a network problem, leaving no way to diagnose what actually went wrong.

### Fix — two-sided

**Server: always return JSON from `/api/*`**

- New `Api::BaseController` that every `Api::` controller now inherits from (`SessionsController`, `PlayersController`, `ScoresController`, `VersionController`)
- `rescue_from` chain covers `StandardError` → 500, `RecordInvalid` → 422, `RecordNotFound` → 404, `ParameterMissing` → 400, each rendering `{ error: "…" }` JSON
- In non-production environments the payload also includes the exception class + top 5 backtrace frames so we can triage without tailing logs
- Production leaks nothing beyond *"Something went wrong on our end. Please try again."*
- Subtle `rescue_from` gotcha: matches last-registered-first, so the `StandardError` fallback is registered **before** the specific handlers

**Client: surface what actually failed**

- New `apiFetch(url, options)` helper in `index.html`'s auth IIFE
- Returns `{ ok, status, data }`. When the body isn't valid JSON it throws a specific `Error` with the HTTP status and a 120-char snippet, so the UI shows e.g.  
  *"Server error (HTTP 502): Bad Gateway"*  
  instead of the old misleading  
  *"Could not reach the server"*
- `doLogin` / `doRegister` now `console.error(err)` for full context and set the surfaced message
- Both also send `Accept: application/json`

### Tests

- `Api::BaseControllerTest` uses a throwaway `ExplodingController` mounted at `/__exploding/{boom,missing,invalid}` to prove the JSON-for-everything handlers end-to-end (500 / 404 / 422 + debug info in non-prod)
- **186 runs, 552 assertions, 0 failures**

### What this does *not* fix

The underlying cause of whatever server-side exception was being raised in production (if any). But from now on, the next time it happens, the user sees the actual HTTP status + response snippet — a diagnosable message, not a generic network-error red herring.