### PR TITLE
Responsive canvas scaling + safe-area-aware touch controls (closes #10, #11)

### DIFF
--- a/public/controls.js
+++ b/public/controls.js
@@ -34,11 +34,16 @@
     }));
   }
 
-  // Inject styles
+  // Inject styles. Control positions use env(safe-area-inset-*) so the
+  // joystick, action buttons, and pause button clear the iOS notch and
+  // home indicator (addresses part of #12's audit + closes #11).
   var style = document.createElement('style');
   style.textContent =
     '.ez-controls{position:fixed;top:0;left:0;right:0;bottom:0;pointer-events:none;z-index:20}' +
-    '.ez-joy-base{position:absolute;bottom:24px;left:24px;pointer-events:auto;' +
+    '.ez-joy-base{position:absolute;' +
+      'bottom:max(env(safe-area-inset-bottom),24px);' +
+      'left:max(env(safe-area-inset-left),24px);' +
+      'pointer-events:auto;' +
       'width:min(30vw,150px);height:min(30vw,150px);border-radius:50%;' +
       'background:rgba(255,255,255,0.08);border:2px solid rgba(255,255,255,0.2);' +
       'touch-action:none;-webkit-user-select:none;user-select:none}' +
@@ -47,7 +52,10 @@
       'top:50%;left:50%;transform:translate(-50%,-50%);pointer-events:none;' +
       'transition:background 0.1s}' +
     '.ez-joy-base.active .ez-joy-knob{background:rgba(255,255,255,0.5)}' +
-    '.ez-btn-area{position:absolute;bottom:24px;right:24px;pointer-events:auto;' +
+    '.ez-btn-area{position:absolute;' +
+      'bottom:max(env(safe-area-inset-bottom),24px);' +
+      'right:max(env(safe-area-inset-right),24px);' +
+      'pointer-events:auto;' +
       'display:flex;flex-direction:column;gap:12px;align-items:center;touch-action:none;' +
       '-webkit-user-select:none;user-select:none}' +
     '.ez-btn{width:64px;height:64px;border-radius:50%;' +
@@ -56,7 +64,9 @@
       'font-family:"Press Start 2P",monospace;font-size:10px;touch-action:none;' +
       '-webkit-user-select:none;user-select:none}' +
     '.ez-btn.active{background:rgba(255,255,255,0.3);border-color:rgba(255,255,255,0.5)}' +
-    '.ez-btn-pause{width:40px;height:40px;font-size:14px;position:absolute;top:44px;right:12px;' +
+    '.ez-btn-pause{width:40px;height:40px;font-size:14px;position:absolute;' +
+      'top:max(env(safe-area-inset-top),44px);' +
+      'right:max(env(safe-area-inset-right),12px);' +
       'pointer-events:auto;border-radius:50%;' +
       'background:rgba(255,255,255,0.08);border:2px solid rgba(255,255,255,0.2);' +
       'color:rgba(255,255,255,0.6);display:flex;align-items:center;justify-content:center;' +

--- a/public/game-viewport.js
+++ b/public/game-viewport.js
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Jay Killeen
+//
+// Shared viewport + canvas-scaling helper for EZ-AZ games.
+//
+// Why this exists:
+//   Most EZ-AZ games draw into a fixed-size canvas (e.g. 700x800). On
+//   mobile that canvas is wider and taller than the viewport, so the
+//   game either overflows the screen (with overflow:hidden cropping
+//   the edges) or forces the player to pinch-zoom out, which also
+//   shrinks the touch controls to the point of being unusable.
+//   See issue #10 (Bloom) and #12 (audit) for the full picture.
+//
+// What it does:
+//   - Locks default mobile gestures that get in the way of gameplay
+//     (text selection, double-tap zoom, pull-to-refresh)
+//   - Exposes EzAzGame.fitCanvas(canvas, { aspect? }) which sizes the
+//     canvas's *CSS* width/height to fit within the viewport while
+//     preserving the canvas's intrinsic render resolution. Drawing
+//     code doesn't change — the browser scales the rendered bitmap to
+//     the CSS size.
+//   - Listens for resize and orientationchange so rotating a phone
+//     mid-game keeps the canvas fitted.
+//   - Never scales the canvas larger than its intrinsic size, so
+//     desktop users still see the crisp, un-upscaled art.
+
+(function () {
+  // Body-level gesture hygiene. Injected as a shared stylesheet so
+  // each game doesn't have to repeat it.
+  var style = document.createElement("style");
+  style.setAttribute("data-ez-az", "viewport");
+  style.textContent =
+    "html, body { touch-action: manipulation;" +
+    "  -webkit-user-select: none; user-select: none;" +
+    "  -webkit-tap-highlight-color: transparent;" +
+    "  overscroll-behavior: none; }";
+  document.head.appendChild(style);
+
+  function fitCanvas(canvas, opts) {
+    if (!canvas) return null;
+    opts = opts || {};
+
+    var intrinsicW = canvas.width;
+    var intrinsicH = canvas.height;
+    var aspect = opts.aspect || (intrinsicW / intrinsicH);
+
+    function resize() {
+      var maxW = window.innerWidth;
+      var maxH = window.innerHeight;
+
+      // Largest size that fits within the viewport AND preserves aspect,
+      // capped at the intrinsic bitmap so desktop doesn't upscale.
+      var w = Math.min(intrinsicW, maxW, maxH * aspect);
+      var h = w / aspect;
+
+      canvas.style.width  = w + "px";
+      canvas.style.height = h + "px";
+      canvas.style.display = "block";
+    }
+
+    resize();
+    // Defer to the next frame so any game CSS that changes body size
+    // (banners, overlays) is applied before we measure.
+    requestAnimationFrame(resize);
+
+    window.addEventListener("resize", resize);
+    window.addEventListener("orientationchange", function () {
+      // orientationchange fires slightly before innerWidth/innerHeight
+      // update on some platforms; a second tick catches the new size.
+      requestAnimationFrame(resize);
+      setTimeout(resize, 150);
+    });
+
+    return { resize: resize };
+  }
+
+  window.EzAzGame = window.EzAzGame || {};
+  window.EzAzGame.fitCanvas = fitCanvas;
+})();

--- a/public/games/bloom.html
+++ b/public/games/bloom.html
@@ -4,8 +4,9 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/game-viewport.js"></script>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <title>Bloom - By Az</title>
@@ -93,6 +94,7 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const W = canvas.width = 700, H = canvas.height = 800;
+if (window.EzAzGame) EzAzGame.fitCanvas(canvas);
 
 // Game state
 let state = 'title'; // title, playing, paused, end

--- a/public/games/cat-vs-mouse.html
+++ b/public/games/cat-vs-mouse.html
@@ -4,8 +4,9 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/game-viewport.js"></script>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Cat Vs Mouse – by Lil</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -147,6 +148,7 @@ if (!CanvasRenderingContext2D.prototype.roundRect) {
 
 const canvas = document.getElementById('gameCanvas');
 const ctx    = canvas.getContext('2d');
+if (window.EzAzGame) EzAzGame.fitCanvas(canvas);
 const overlay  = document.getElementById('overlay');
 const startBtn = document.getElementById('startBtn');
 

--- a/public/games/descent.html
+++ b/public/games/descent.html
@@ -4,8 +4,9 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/game-viewport.js"></script>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <title>Descent - EZ-AZ</title>
@@ -155,6 +156,7 @@ var canvas = document.getElementById('game');
 var ctx = canvas.getContext('2d');
 var W = canvas.width = 700;
 var H = canvas.height = 800;
+if (window.EzAzGame) EzAzGame.fitCanvas(canvas);
 
 // Offscreen canvas for fog of war (so destination-out only affects the fog layer)
 var fogCanvas = document.createElement('canvas');

--- a/public/games/dodgeball.html
+++ b/public/games/dodgeball.html
@@ -4,8 +4,9 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/game-viewport.js"></script>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <title>Dodgeball - World Championship 1988</title>
@@ -81,6 +82,7 @@
 var canvas = document.getElementById('game');
 var ctx = canvas.getContext('2d');
 var W = canvas.width = 700, H = canvas.height = 560;
+if (window.EzAzGame) EzAzGame.fitCanvas(canvas);
 var COURT_TOP = 40, COURT_BOTTOM = H - 20, COURT_LEFT = 30, COURT_RIGHT = W - 30;
 var COURT_W = COURT_RIGHT - COURT_LEFT, COURT_H = COURT_BOTTOM - COURT_TOP;
 var CENTER_Y = COURT_TOP + COURT_H / 2;

--- a/public/games/space-dodge.html
+++ b/public/games/space-dodge.html
@@ -4,7 +4,9 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/game-viewport.js"></script>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <title>Charlie & Cooper's Space Dodge!</title>
@@ -86,6 +88,7 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 const W = canvas.width = 700, H = canvas.height = 800;
+if (window.EzAzGame) EzAzGame.fitCanvas(canvas);
 
 // ===== LEADERBOARD =====
 let leaderboardCache = [];

--- a/test/integration/static_files_test.rb
+++ b/test/integration/static_files_test.rb
@@ -224,6 +224,55 @@ class StaticFilesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Shared game-viewport helper (#11)
+
+  test "game-viewport js is served" do
+    get "/game-viewport.js"
+    assert_response :success
+    assert_match(/javascript/, response.content_type)
+  end
+
+  test "game-viewport js exposes EzAzGame.fitCanvas" do
+    get "/game-viewport.js"
+    assert_includes response.body, "EzAzGame"
+    assert_includes response.body, "fitCanvas"
+    assert_includes response.body, "orientationchange"
+  end
+
+  test "every scalable game page includes the viewport helper and calls fitCanvas" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent].each do |slug|
+      get "/games/#{slug}.html"
+      assert_response :success
+      assert_includes response.body, %(src="/game-viewport.js"),
+        "#{slug} is missing the shared viewport script"
+      assert_includes response.body, "EzAzGame.fitCanvas(canvas)",
+        "#{slug} is not calling EzAzGame.fitCanvas(canvas)"
+    end
+  end
+
+  test "every game page declares a viewport meta" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent corrupted].each do |slug|
+      get "/games/#{slug}.html"
+      assert_match(/<meta[^>]+name="viewport"[^>]+width=device-width/, response.body,
+        "#{slug} is missing a viewport meta tag")
+    end
+  end
+
+  test "scalable games opt into viewport-fit=cover for safe-area insets" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent].each do |slug|
+      get "/games/#{slug}.html"
+      assert_match(/viewport-fit=cover/, response.body,
+        "#{slug} should use viewport-fit=cover so env(safe-area-inset-*) is populated")
+    end
+  end
+
+  test "controls js uses env(safe-area-inset-*) for control positioning" do
+    get "/controls.js"
+    assert_response :success
+    assert_match(/safe-area-inset-bottom/, response.body)
+    assert_match(/safe-area-inset-top/,    response.body)
+  end
+
   # Corrupted game box on shelf
 
   test "index has corrupted link" do


### PR DESCRIPTION
Closes jaykilleen/easy-az#11, closes jaykilleen/easy-az#10.

Implements the canvas-scaling helper recommended in the jaykilleen/easy-az#12 audit. The real cause of jaykilleen/easy-az#10 wasn't the controls — it was that Bloom's 700×800 intrinsic canvas overflows a phone viewport, so players pinch-zoom out, which also shrinks `position:fixed` controls to the point of being unusable. Fixing the canvas side makes the controls usable again without touching them.

### What ships

**`public/game-viewport.js`** (new)
- Shared helper loaded near the top of every game
- Injects page-level styles for `touch-action: manipulation`, `user-select: none`, `-webkit-tap-highlight-color: transparent`, `overscroll-behavior: none` so mobile gestures don't fight the canvas
- Exposes `EzAzGame.fitCanvas(canvas, { aspect? })` that scales the canvas's CSS size to fit the viewport while preserving its intrinsic bitmap resolution — drawing code is unchanged
- Capped at intrinsic size so desktop isn't upscaled
- Refits on `resize` + `orientationchange` (with a 150ms kicker for iOS lag)

**`public/controls.js`**
- Joystick, action-button column, and pause button now use `max(env(safe-area-inset-*), fallback-px)` so controls clear iOS notch and home-indicator gesture area

**Every scalable game** (`space-dodge`, `bloom`, `cat-vs-mouse`, `dodgeball`, `descent`)
- Added `<script src="/game-viewport.js">` in `<head>`
- Single-line `EzAzGame.fitCanvas(canvas)` after canvas creation
- Viewport meta upgraded with `viewport-fit=cover`; **Space Dodge** picks up a viewport meta for the first time (was missing)

**`corrupted.html`** deliberately left alone — has its own `resizeCanvas` (800×500 aspect) and its input problem is pointer-lock / mouse-look, covered separately by future work.

### Expected effect on a 375×667 phone

- A 700×800 canvas renders at 375×429 CSS pixels (scale ≈0.53) — no viewport overflow
- Players don't pinch-zoom, so the `position:fixed` joystick + FIRE button stay full-size
- Safe-area-aware placements clear the home-indicator gesture zone
- Landscape 667×375 → canvas at 328×375
- Desktop 1920×1080 → canvas stays at intrinsic 700×800 (never scaled up)

### Tests
- `/game-viewport.js` is served, exposes `EzAzGame.fitCanvas`, handles `orientationchange`
- Every scalable game includes the helper and calls `fitCanvas(canvas)`
- Every game has a viewport meta; scalable games opt into `viewport-fit=cover`
- `controls.js` uses `env(safe-area-inset-{top,bottom})`
- **192 runs, 613 assertions, 0 failures**

### Still open (scope of jaykilleen/easy-az#14 / jaykilleen/easy-az#15)

Space Dodge and Dodgeball don't yet reference `/controls.js`, so they're keyboard-only on mobile. The viewport work here is the foundation those follow-ups will build on.