### PR TITLE
Add touch controls to Space Dodge (1-player mode) (closes #14)

### DIFF
--- a/public/games/space-dodge.html
+++ b/public/games/space-dodge.html
@@ -913,6 +913,7 @@ function draw() {
 
 function loop(){if(!started||paused)return;update();draw();if(players.some(p=>p.alive)||particles.length>0)requestAnimationFrame(loop);}
 </script>
+<script src="/controls.js" data-buttons="shoot"></script>
 <script src="/room-input.js"></script>
 </body>
 </html>

--- a/test/integration/static_files_test.rb
+++ b/test/integration/static_files_test.rb
@@ -273,6 +273,27 @@ class StaticFilesTest < ActionDispatch::IntegrationTest
     assert_match(/safe-area-inset-top/,    response.body)
   end
 
+  # Touch-controlled games (#14, #15 and earlier bloom/cat/descent)
+  # All 1-player games that accept Space Dodge-style touch controls
+  # should reference the shared /controls.js so they're playable
+  # without a keyboard.
+
+  test "space-dodge references controls.js with a shoot button" do
+    get "/games/space-dodge.html"
+    assert_includes response.body, %(src="/controls.js"),
+      "space-dodge should include /controls.js for mobile playability (#14)"
+    assert_match(/data-buttons="shoot"/, response.body,
+      "space-dodge's controls should expose a shoot button for firing")
+  end
+
+  test "descent references controls.js with a sprint button" do
+    get "/games/descent.html"
+    assert_includes response.body, %(src="/controls.js"),
+      "descent should include /controls.js for mobile playability (#15)"
+    assert_match(/data-buttons="sprint"/, response.body,
+      "descent's controls should expose a sprint button")
+  end
+
   # Corrupted game box on shelf
 
   test "index has corrupted link" do


### PR DESCRIPTION
Closes jaykilleen/easy-az#14.

The game already accepts both `ShiftRight` and `ShiftLeft` for firing in 1-player mode (`{shoot: 'ShiftRight', shoot2: 'ShiftLeft'}` at space-dodge.html:715). The shared `controls.js` `shoot` profile dispatches `ShiftLeft`, which lines up with `shoot2`, so a touch player can fire without any changes to the game's input handling.

One-liner:

```html
<script src="/controls.js" data-buttons="shoot"></script>
```

added right before the `room-input.js` include, so the shared touch overlay draws a joystick for arrow-key movement and a FIRE button for firing.

### Why this works on mobile now

- The canvas-fitting helper shipped in jaykilleen/easy-az#11 means Space Dodge's 700×800 canvas renders at ~375×429 on a phone — no pinch-zoom needed, so `position:fixed` controls stay full-size
- `controls.js` now uses `env(safe-area-inset-*)`, so FIRE sits above the home-indicator gesture area on modern iPhones

### Tests

- New integration test pins `space-dodge.html` → `/controls.js` + `data-buttons="shoot"`
- Companion test for Descent pins its existing `data-buttons="sprint"` wiring (prevents a regression against jaykilleen/easy-az#15)
- **194 runs, 621 assertions, 0 failures**

### Scope notes

2-player mode is still keyboard-only — two simultaneous players on one touch surface needs either the phone-as-controller flow from jaykilleen/easy-az#4 (already shipped) or game-specific split-screen controls. Out of scope here.