### PR TITLE
Public error tracker at /errors (closes #33)

### DIFF
--- a/app/controllers/api/errors_controller.rb
+++ b/app/controllers/api/errors_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  class ErrorsController < BaseController
+    # POST /api/errors
+    # Body: { message, stack, game, user_agent, url }
+    #
+    # Called by public/error-reporter.js whenever an uncaught exception
+    # or rejected promise happens in a game page. Best-effort capture:
+    # we never return an error body that could itself get reported as
+    # an error by the reporter (which would create a crash loop).
+    def create
+      body = JSON.parse(request.body.read) rescue {}
+      report = ErrorReport.record!(
+        message:    body["message"],
+        stack:      body["stack"],
+        game:       body["game"],
+        user_agent: body["user_agent"],
+        url:        body["url"]
+      )
+
+      if report
+        render json: { fingerprint: report.fingerprint, occurrences: report.occurrences }, status: :created
+      else
+        # Silent no-op for blank messages — never surface an error to the reporter.
+        render json: { ok: true }, status: :accepted
+      end
+    end
+  end
+end

--- a/app/controllers/errors_dashboard_controller.rb
+++ b/app/controllers/errors_dashboard_controller.rb
@@ -1,0 +1,9 @@
+# Public dashboard at /errors. Renamed from ErrorsController (which
+# already exists and handles 404/500 templates) so the two don't
+# collide.
+class ErrorsDashboardController < ApplicationController
+  def index
+    @reports = ErrorReport.recent.limit(50)
+    @total   = ErrorReport.count
+  end
+end

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -1,0 +1,62 @@
+require "digest/sha1"
+
+class ErrorReport < ApplicationRecord
+  MESSAGE_MAX = 500
+  STACK_MAX   = 10_000    # plenty for a typical JS stack, protects the DB
+
+  validates :fingerprint,   presence: true, uniqueness: true
+  validates :message,       presence: true
+  validates :occurrences,   numericality: { greater_than: 0 }
+  validates :first_seen_at, :last_seen_at, presence: true
+
+  scope :recent,     -> { order(last_seen_at: :desc) }
+  scope :for_game,   ->(game) { where(game: game) }
+
+  # Given the raw client payload, build-or-update the matching ErrorReport.
+  # Dedups by fingerprint: same message + top stack frame + game = same
+  # report, just with a higher occurrence count.
+  def self.record!(attrs)
+    attrs = attrs.with_indifferent_access
+    message = attrs[:message].to_s.strip
+    return nil if message.blank?
+
+    message = message[0, MESSAGE_MAX]
+    stack   = attrs[:stack].to_s[0, STACK_MAX]
+    game    = attrs[:game].to_s.presence
+    fp      = fingerprint_for(message: message, stack: stack, game: game)
+
+    now = Time.current
+    record = find_or_initialize_by(fingerprint: fp)
+
+    if record.new_record?
+      record.assign_attributes(
+        message:       message,
+        stack:         stack,
+        game:          game,
+        user_agent:    attrs[:user_agent].to_s[0, MESSAGE_MAX].presence,
+        url:           attrs[:url].to_s[0, MESSAGE_MAX].presence,
+        first_seen_at: now,
+        last_seen_at:  now,
+        occurrences:   1
+      )
+      record.save!
+    else
+      # Atomic: don't fetch the counter Ruby-side, let SQLite handle it.
+      where(id: record.id).update_all([
+        "occurrences = occurrences + 1, last_seen_at = ?, updated_at = ?",
+        now, now
+      ])
+      record.reload
+    end
+
+    record
+  end
+
+  # Deterministic fingerprint keyed on the high-signal bits: message,
+  # first stack frame, game. Different games throwing the same
+  # "undefined is not a function" are still treated as different bugs.
+  def self.fingerprint_for(message:, stack:, game:)
+    first_frame = stack.to_s.lines.first.to_s.strip
+    Digest::SHA1.hexdigest("#{message}\0#{first_frame}\0#{game}")[0, 16]
+  end
+end

--- a/app/views/errors_dashboard/index.html.erb
+++ b/app/views/errors_dashboard/index.html.erb
@@ -1,0 +1,111 @@
+<% content_for :title, "Errors on EZ-AZ" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Errors on EZ-AZ</title>
+  <meta name="theme-color" content="#0a0a12">
+  <style>
+    *,*::before,*::after { box-sizing: border-box; }
+    html,body { margin: 0; background: #0a0a12; color: #cfe;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    a { color: #00ffc8; }
+    .page { max-width: 1100px; margin: 0 auto; padding: 24px 20px 60px; }
+    header { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+    h1 { font-size: clamp(1.8rem, 3vw, 2.4rem); margin: 0;
+         background: linear-gradient(135deg, #00ffc8, #00a3ff, #ff00aa);
+         -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .subtitle { color: #8ab4c8; font-size: 14px; max-width: 640px; line-height: 1.5; }
+    .count { font-family: "Courier New", monospace; color: #8ab4c8; font-size: 13px; white-space: nowrap; }
+
+    table { width: 100%; border-collapse: collapse; background: #13131f;
+            border-radius: 8px; overflow: hidden; box-shadow: 0 0 0 1px rgba(0,255,200,0.08); }
+    th, td { text-align: left; padding: 10px 12px; vertical-align: top; font-size: 13px; }
+    th { background: #1a1a2e; color: #00ffc8; font-weight: 700; font-size: 11px;
+         text-transform: uppercase; letter-spacing: 0.1em; }
+    tr + tr td { border-top: 1px solid rgba(255,255,255,0.04); }
+    td.msg { max-width: 520px; color: #fff; font-family: "SF Mono", "Menlo", monospace; font-size: 12px; }
+    td.msg code { background: #0a0a12; padding: 2px 6px; border-radius: 4px; display: inline-block; }
+    td.game { color: #ff00aa; font-weight: 600; text-transform: lowercase; font-size: 12px; }
+    td.game.empty { color: #556; font-style: italic; font-weight: 400; }
+    td.count-col { text-align: right; font-family: "Courier New", monospace; color: #00ffc8; width: 80px; }
+    td.seen { color: #8ab4c8; font-family: "Courier New", monospace; font-size: 12px; white-space: nowrap; }
+
+    .stack { font-family: "SF Mono", Menlo, Consolas, monospace; font-size: 11px;
+             color: #aaa; white-space: pre-wrap; margin-top: 6px; padding: 8px;
+             background: #0a0a12; border-radius: 4px; max-height: 140px; overflow: auto; }
+    details summary { cursor: pointer; color: #667; font-size: 11px; }
+    details[open] summary { color: #00ffc8; }
+
+    .empty { text-align: center; padding: 60px 20px; color: #667; font-style: italic; }
+    footer { margin-top: 32px; text-align: center; color: #556; font-size: 12px; line-height: 1.6; }
+    footer a { color: #8ab4c8; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <div>
+        <h1>Errors on EZ-AZ</h1>
+        <p class="subtitle">
+          Real errors captured from real gameplay. When a game crashes, Az catches
+          the exception and logs it here so we can learn from it — yours too.
+          <strong>Errors aren't failures, they're how we find bugs.</strong>
+        </p>
+      </div>
+      <div class="count">
+        <%= @total %> unique · showing <%= @reports.size %>
+      </div>
+    </header>
+
+    <% if @reports.any? %>
+      <table>
+        <thead>
+          <tr>
+            <th>Error</th>
+            <th>Game</th>
+            <th style="text-align:right;">Count</th>
+            <th>Last seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @reports.each do |report| %>
+            <tr>
+              <td class="msg">
+                <code><%= report.message %></code>
+                <% if report.stack.present? %>
+                  <details>
+                    <summary>stack trace</summary>
+                    <div class="stack"><%= report.stack %></div>
+                  </details>
+                <% end %>
+              </td>
+              <td class="<%= report.game.present? ? "game" : "game empty" %>">
+                <%= report.game.presence || "—" %>
+              </td>
+              <td class="count-col"><%= report.occurrences %>x</td>
+              <td class="seen"><%= time_ago_in_words(report.last_seen_at) %> ago</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="empty">
+        No errors yet — either EZ-AZ is running perfectly, or the error reporter
+        hasn't caught anything here.
+      </div>
+    <% end %>
+
+    <footer>
+      <p>
+        <a href="/">&larr; Back to EZ-AZ</a>
+        &nbsp;·&nbsp;
+        <a href="https://github.com/jaykilleen/easy-az">Source on GitHub</a>
+      </p>
+      <p>Errors are grouped by message + top stack frame + game.
+        Nothing about who you are is collected — just the technical details.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,10 @@ Rails.application.routes.draw do
     resources :players, only: [:create] do
       collection { get :check }
     end
+    resources :errors,  only: [:create]
   end
+
+  get "/errors", to: "errors_dashboard#index"
 
   match "/404", to: "errors#not_found",       via: :all
   match "/500", to: "errors#internal_error",  via: :all

--- a/db/migrate/20260416000001_create_error_reports.rb
+++ b/db/migrate/20260416000001_create_error_reports.rb
@@ -1,0 +1,20 @@
+class CreateErrorReports < ActiveRecord::Migration[8.0]
+  def change
+    create_table :error_reports do |t|
+      t.string   :fingerprint,    null: false
+      t.string   :message,        null: false, limit: 500
+      t.text     :stack
+      t.string   :game
+      t.string   :user_agent,     limit: 500
+      t.string   :url,            limit: 500
+      t.integer  :occurrences,    null: false, default: 1
+      t.datetime :first_seen_at,  null: false
+      t.datetime :last_seen_at,   null: false
+      t.timestamps
+    end
+
+    add_index :error_reports, :fingerprint,   unique: true
+    add_index :error_reports, :last_seen_at
+    add_index :error_reports, :game
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000011) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_000001) do
   create_table "counters", force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 0, null: false
     t.index ["key"], name: "index_counters_on_key", unique: true
+  end
+
+  create_table "error_reports", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "fingerprint", null: false
+    t.datetime "first_seen_at", null: false
+    t.string "game"
+    t.datetime "last_seen_at", null: false
+    t.string "message", limit: 500, null: false
+    t.integer "occurrences", default: 1, null: false
+    t.text "stack"
+    t.datetime "updated_at", null: false
+    t.string "url", limit: 500
+    t.string "user_agent", limit: 500
+    t.index ["fingerprint"], name: "index_error_reports_on_fingerprint", unique: true
+    t.index ["game"], name: "index_error_reports_on_game"
+    t.index ["last_seen_at"], name: "index_error_reports_on_last_seen_at"
   end
 
   create_table "players", force: :cascade do |t|

--- a/public/error-reporter.js
+++ b/public/error-reporter.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Jay Killeen
+//
+// Capture-and-report bridge for the EZ-AZ public error tracker (#33).
+//
+// Hooks window.onerror and unhandledrejection, POSTs errors to
+// /api/errors, and keeps a per-page-load Set of fingerprints so the
+// same error doesn't spam the server from a tight game loop.
+//
+// By design this script NEVER throws — if it couldn't post, it silently
+// drops the report. An error reporter that errors while reporting
+// errors is its own special kind of hell.
+
+(function () {
+  if (window.EzAzErrors) return;   // idempotent
+  window.EzAzErrors = true;
+
+  var seen = new Set();
+
+  function fingerprint(message, stack) {
+    var firstFrame = (stack || "").split("\n", 1)[0] || "";
+    return (message || "").slice(0, 200) + "\0" + firstFrame.slice(0, 200);
+  }
+
+  function gameSlug() {
+    var match = location.pathname.match(/\/games\/([a-z0-9-]+)\.html$/i);
+    return match ? match[1].toLowerCase() : null;
+  }
+
+  function send(payload) {
+    try {
+      var body = JSON.stringify(payload);
+      // sendBeacon works even during page unload; fall back to fetch.
+      var url = "/api/errors";
+      if (navigator.sendBeacon) {
+        var blob = new Blob([body], { type: "application/json" });
+        if (navigator.sendBeacon(url, blob)) return;
+      }
+      fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: body,
+        keepalive: true
+      }).catch(function () { /* swallow */ });
+    } catch (e) {
+      // never let the reporter itself throw
+    }
+  }
+
+  function report(message, stack, extra) {
+    message = (message || "").toString();
+    stack   = (stack   || "").toString();
+    var fp = fingerprint(message, stack);
+    if (seen.has(fp)) return;
+    seen.add(fp);
+
+    send({
+      message:    message,
+      stack:      stack,
+      game:       gameSlug(),
+      user_agent: navigator.userAgent,
+      url:        location.pathname + location.search,
+      extra:      extra || null
+    });
+  }
+
+  window.addEventListener("error", function (event) {
+    var err = event.error;
+    var message = (err && err.message) || event.message || "Unknown error";
+    var stack   = (err && err.stack)   || (event.filename + ":" + event.lineno + ":" + event.colno);
+    report(message, stack);
+  });
+
+  window.addEventListener("unhandledrejection", function (event) {
+    var reason = event.reason;
+    var message, stack;
+    if (reason && typeof reason === "object") {
+      message = reason.message || String(reason);
+      stack   = reason.stack   || "";
+    } else {
+      message = "Unhandled promise rejection: " + String(reason);
+      stack   = "";
+    }
+    report(message, stack, { kind: "unhandledrejection" });
+  });
+
+  // Expose for manual/test use.
+  window.EzAzReportError = report;
+})();

--- a/public/games/bloom.html
+++ b/public/games/bloom.html
@@ -5,6 +5,7 @@
 <head>
 <script src="/opening-hours.js"></script>
 <script src="/game-viewport.js"></script>
+<script src="/error-reporter.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/cat-vs-mouse.html
+++ b/public/games/cat-vs-mouse.html
@@ -5,6 +5,7 @@
 <head>
 <script src="/opening-hours.js"></script>
 <script src="/game-viewport.js"></script>
+<script src="/error-reporter.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Cat Vs Mouse – by Lil</title>

--- a/public/games/corrupted.html
+++ b/public/games/corrupted.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <script src="/opening-hours.js"></script>
+<script src="/error-reporter.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Corrupted - EZ-AZ</title>

--- a/public/games/descent.html
+++ b/public/games/descent.html
@@ -5,6 +5,7 @@
 <head>
 <script src="/opening-hours.js"></script>
 <script src="/game-viewport.js"></script>
+<script src="/error-reporter.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/dodgeball.html
+++ b/public/games/dodgeball.html
@@ -5,6 +5,7 @@
 <head>
 <script src="/opening-hours.js"></script>
 <script src="/game-viewport.js"></script>
+<script src="/error-reporter.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/games/space-dodge.html
+++ b/public/games/space-dodge.html
@@ -5,6 +5,7 @@
 <head>
 <script src="/opening-hours.js"></script>
 <script src="/game-viewport.js"></script>
+<script src="/error-reporter.js"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <script src="/opening-hours.js"></script>
+  <script src="/error-reporter.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EZ-AZ - The Family Video Game Store</title>

--- a/test/controllers/api/errors_controller_test.rb
+++ b/test/controllers/api/errors_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Api::ErrorsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    ErrorReport.delete_all
+  end
+
+  test "POST /api/errors creates an ErrorReport" do
+    assert_difference -> { ErrorReport.count }, 1 do
+      post "/api/errors",
+           params: { message: "boom", stack: "at foo (x:1)", game: "bloom" }.to_json,
+           headers: { "CONTENT_TYPE" => "application/json" }
+    end
+    assert_response :created
+    data = JSON.parse(response.body)
+    assert data["fingerprint"].present?
+    assert_equal 1, data["occurrences"]
+  end
+
+  test "identical errors return the same fingerprint with bumped occurrences" do
+    post "/api/errors", params: { message: "boom", stack: "at foo (x:1)", game: "bloom" }.to_json,
+         headers: { "CONTENT_TYPE" => "application/json" }
+    first = JSON.parse(response.body)
+
+    post "/api/errors", params: { message: "boom", stack: "at foo (x:1)", game: "bloom" }.to_json,
+         headers: { "CONTENT_TYPE" => "application/json" }
+    second = JSON.parse(response.body)
+
+    assert_equal first["fingerprint"], second["fingerprint"]
+    assert_equal 2, second["occurrences"]
+    assert_equal 1, ErrorReport.count
+  end
+
+  test "blank message returns 202 without creating a report" do
+    assert_no_difference -> { ErrorReport.count } do
+      post "/api/errors", params: { message: "" }.to_json,
+           headers: { "CONTENT_TYPE" => "application/json" }
+    end
+    assert_response :accepted
+  end
+
+  test "invalid JSON body is handled gracefully" do
+    assert_no_difference -> { ErrorReport.count } do
+      post "/api/errors", params: "not-json",
+           headers: { "CONTENT_TYPE" => "application/json" }
+    end
+    assert_response :accepted
+  end
+end

--- a/test/controllers/errors_dashboard_controller_test.rb
+++ b/test/controllers/errors_dashboard_controller_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class ErrorsDashboardControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    ErrorReport.delete_all
+  end
+
+  test "GET /errors renders empty state when there are no reports" do
+    get "/errors"
+    assert_response :success
+    assert_includes response.body, "Errors on EZ-AZ"
+    assert_includes response.body, "No errors yet"
+  end
+
+  test "GET /errors lists recent reports" do
+    ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "bloom")
+    get "/errors"
+    assert_response :success
+    assert_includes response.body, "boom"
+    assert_includes response.body, "bloom"
+    assert_match %r{1x}, response.body
+  end
+
+  test "GET /errors sorts newest first" do
+    old = ErrorReport.record!(message: "old", stack: "a")
+    old.update!(last_seen_at: 1.day.ago)
+    ErrorReport.record!(message: "new", stack: "b")
+
+    get "/errors"
+    assert response.body.index("new") < response.body.index("old"),
+      "newer errors should appear before older ones"
+  end
+
+  test "GET /errors displays the total unique-error count" do
+    3.times { |i| ErrorReport.record!(message: "err #{i}", stack: "x#{i}") }
+    get "/errors"
+    assert_match %r{3 unique}, response.body
+  end
+end

--- a/test/integration/static_files_test.rb
+++ b/test/integration/static_files_test.rb
@@ -224,6 +224,30 @@ class StaticFilesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Error reporter (#33)
+
+  test "error-reporter.js is served" do
+    get "/error-reporter.js"
+    assert_response :success
+    assert_match(/javascript/, response.content_type)
+    assert_includes response.body, "EzAzErrors"
+    assert_includes response.body, "/api/errors"
+  end
+
+  test "every game page includes the error reporter" do
+    %w[space-dodge bloom cat-vs-mouse dodgeball descent corrupted].each do |slug|
+      get "/games/#{slug}.html"
+      assert_includes response.body, %(src="/error-reporter.js"),
+        "#{slug} should include the shared error-reporter.js"
+    end
+  end
+
+  test "index page includes the error reporter" do
+    get "/"
+    assert_includes response.body, %(src="/error-reporter.js"),
+      "the store index should include the shared error-reporter.js"
+  end
+
   # Shared game-viewport helper (#11)
 
   test "game-viewport js is served" do

--- a/test/models/error_report_test.rb
+++ b/test/models/error_report_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class ErrorReportTest < ActiveSupport::TestCase
+  setup do
+    ErrorReport.delete_all
+  end
+
+  test "record! creates a new report on first sighting" do
+    assert_difference -> { ErrorReport.count }, 1 do
+      ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "bloom")
+    end
+    r = ErrorReport.last
+    assert_equal "boom",         r.message
+    assert_equal "at foo (x:1)", r.stack
+    assert_equal "bloom",        r.game
+    assert_equal 1, r.occurrences
+    assert_not_nil r.fingerprint
+  end
+
+  test "record! dedups by fingerprint and bumps occurrences + last_seen_at" do
+    r1 = ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "bloom")
+    assert_equal 1, r1.occurrences
+
+    r2 = ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "bloom")
+    assert_equal r1.id, r2.id
+    assert_equal 2, r2.occurrences
+    assert_operator r2.last_seen_at, :>=, r1.last_seen_at
+  end
+
+  test "different messages fingerprint separately" do
+    a = ErrorReport.record!(message: "boom",  stack: "at foo (x:1)", game: "bloom")
+    b = ErrorReport.record!(message: "crash", stack: "at foo (x:1)", game: "bloom")
+    assert_not_equal a.fingerprint, b.fingerprint
+    assert_equal 2, ErrorReport.count
+  end
+
+  test "different games fingerprint separately even for the same error" do
+    a = ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "bloom")
+    b = ErrorReport.record!(message: "boom", stack: "at foo (x:1)", game: "descent")
+    assert_not_equal a.fingerprint, b.fingerprint
+  end
+
+  test "different top stack frames fingerprint separately" do
+    a = ErrorReport.record!(message: "TypeError", stack: "at foo (a.js:1)", game: nil)
+    b = ErrorReport.record!(message: "TypeError", stack: "at bar (b.js:1)", game: nil)
+    assert_not_equal a.fingerprint, b.fingerprint
+  end
+
+  test "blank messages are silently dropped" do
+    assert_nil ErrorReport.record!(message: "",   stack: "whatever")
+    assert_nil ErrorReport.record!(message: "   ", stack: "whatever")
+    assert_nil ErrorReport.record!(message: nil,  stack: "whatever")
+    assert_equal 0, ErrorReport.count
+  end
+
+  test "overlong messages are truncated to MESSAGE_MAX" do
+    long = "x" * (ErrorReport::MESSAGE_MAX + 50)
+    r = ErrorReport.record!(message: long, stack: "")
+    assert_equal ErrorReport::MESSAGE_MAX, r.message.length
+  end
+
+  test "overlong stacks are truncated to STACK_MAX" do
+    long = "y" * (ErrorReport::STACK_MAX + 5_000)
+    r = ErrorReport.record!(message: "boom", stack: long)
+    assert_equal ErrorReport::STACK_MAX, r.stack.length
+  end
+
+  test "recent scope orders by last_seen_at desc" do
+    old = ErrorReport.record!(message: "old",   stack: "a")
+    old.update!(last_seen_at: 1.hour.ago)
+    new = ErrorReport.record!(message: "new",   stack: "b")
+
+    assert_equal [new.id, old.id], ErrorReport.recent.limit(2).pluck(:id)
+  end
+end


### PR DESCRIPTION
Closes jaykilleen/easy-az#33.

Captures runtime errors from every game + the store, dedups them by fingerprint, and renders a public dashboard at `/errors` so kids (and us) can learn from real crashes. Directly embodies the "errors aren't failures, they're how we find bugs" culture the issue asked for.

### What's captured
- Uncaught exceptions (`window.onerror`)
- Unhandled promise rejections (`unhandledrejection`)
- Message, top stack trace, game slug (derived from URL), user-agent, full path
- Nothing about who the user is — purely technical detail

### Dedup
- `fingerprint = sha1(message + first-stack-frame + game)[0, 16]`
- Same shape from the same game = one row, `occurrences++`
- Different games hitting the same `"undefined is not a function"` stay separate so each game's story is distinct

### Server

- `ErrorReport.record!(attrs)` atomically find-or-creates, bumps `occurrences` via a single `update_all("occurrences = occurrences + 1, …")` SQL so a bursty game can't race the counter
- `Api::ErrorsController#create` wraps the same call — blank messages silently return **202**, invalid JSON also silently **202**s. The reporter must *never* get a response body that could itself get reported as an error.
- `ErrorsDashboardController#index` renders the last 50 at `/errors`

### Client (`public/error-reporter.js`)
- Idempotent IIFE; one-line `<script>` added to every game + `index.html`
- `navigator.sendBeacon` when available (survives page unload), fallback to `fetch({ keepalive: true })`
- Per-page-load `Set` of fingerprints prevents a tight loop from spamming
- Exposes `window.EzAzReportError(msg, stack, extra)` for manual reporting
- Defensive: the reporter itself wraps every call in try/catch and silently drops failures

### Dashboard
- Store-aesthetic: dark bg, neon heading gradient, monospace stack
- Columns: message + collapsible stack, game, count, last-seen (relative)
- Empty state copy when the DB is clean
- No JS, no filters yet — just the top 50 newest

### Tests
- `ErrorReportTest` — create, dedup, different messages/games/frames stay separate, blank dropped, truncation, recent scope
- `Api::ErrorsControllerTest` — POST creates, dedup contract, blank→202, invalid-JSON→202 (never 500)
- `ErrorsDashboardControllerTest` — empty state, recent listed, newest first, unique count
- `static_files_test` — `/error-reporter.js` is served, every game + `index.html` includes the script
- **214 runs, 694 assertions, 0 failures**

### Live smoke
```
POST {"message":"TypeError","stack":"at foo (x)","game":"bloom"}  => {"fingerprint":"f8a5…","occurrences":1}
POST same payload                                                   => occurrences:2
POST different payload                                              => new fingerprint, occurrences:1
POST {"message":""}                                                 => 202 {"ok":true}, no row
GET  /errors                                                        => dashboard with 1x / 2x / game names
```

### Not in scope (future follow-ups if wanted)
- Per-game filtering, mark-resolved, detail page
- Server-side rate limiting / spam protection
- Error-count badges on game tiles on the store