### PR TITLE
Code inspector at /code — browse the real EZ-AZ codebase (closes #34)

### DIFF
--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -1,0 +1,109 @@
+# Public code inspector (#34). Kids can browse how EZ-AZ and its games
+# are actually built, with syntax highlighting and line numbers.
+#
+# Security: only paths in CURATED are ever served. The `path` param is
+# compared against the whitelist's relative paths — anything outside is
+# a 404. We never call File.read with an unvalidated user-supplied path.
+class CodeController < ApplicationController
+  # Each entry: { path:, label:, blurb:, category: }
+  # `path` is relative to Rails.root; `category` groups the index.
+  CURATED = [
+    # --- Games: the fun stuff, probably most interesting to kids ---
+    { path: "public/games/space-dodge.html",  label: "Space Dodge",
+      blurb: "Charlie & Cooper's co-op space shooter — bosses, power-ups, robot voice",
+      category: "Games" },
+    { path: "public/games/dodgeball.html",    label: "Dodgeball '88",
+      blurb: "Lachie's top-down 2v2 tournament with a wandering ref and ball boys",
+      category: "Games" },
+    { path: "public/games/corrupted.html",    label: "Corrupted",
+      blurb: "Cooper's first-person zombie fighter — raycasting in plain JS",
+      category: "Games" },
+    { path: "public/games/descent.html",      label: "Descent",
+      blurb: "Jaykill's maze runner with flashlight vision and fog of war",
+      category: "Games" },
+    { path: "public/games/cat-vs-mouse.html", label: "Cat vs Mouse",
+      blurb: "Lil's rope-puzzle game across eight levels",
+      category: "Games" },
+    { path: "public/games/bloom.html",        label: "Bloom",
+      blurb: "Az's chill exploration game — time-based scoring, no pressure",
+      category: "Games" },
+
+    # --- Shared frontend plumbing ---
+    { path: "public/index.html",           label: "The store (index.html)",
+      blurb: "The EZ-AZ store page — leaderboard, visitor counter, login modal, and the Az dinosaur",
+      category: "Store frontend" },
+    { path: "public/controls.js",          label: "Touch controls",
+      blurb: "Virtual joystick + action buttons that make keyboard games playable on phones",
+      category: "Store frontend" },
+    { path: "public/game-viewport.js",     label: "Game viewport helper",
+      blurb: "Scales each game's canvas to fit any screen without upscaling on desktop",
+      category: "Store frontend" },
+    { path: "public/opening-hours.js",     label: "Opening hours",
+      blurb: "Checks if the store is open, handles school-holiday hours, and redirects to /closed.html",
+      category: "Store frontend" },
+    { path: "public/error-reporter.js",    label: "Error reporter",
+      blurb: "Catches runtime errors and sends them to /api/errors for the public error tracker",
+      category: "Store frontend" },
+    { path: "app/views/room_input/show.js.erb", label: "Multiplayer input router",
+      blurb: "TV-side script that turns WebSocket messages from phones into keyboard events (served by Rails as /room-input.js)",
+      category: "Store frontend" },
+
+    # --- Rails backend ---
+    { path: "config/routes.rb",                              label: "All the routes",
+      blurb: "Every URL in EZ-AZ — start here if you want to see what the backend can do",
+      category: "Rails backend" },
+    { path: "app/models/score.rb",                           label: "Score model",
+      blurb: "Per-game leaderboard rows with name normalisation and per-game sort direction",
+      category: "Rails backend" },
+    { path: "app/models/error_report.rb",                    label: "Error report model",
+      blurb: "How the error tracker dedups by message + stack + game to avoid duplicates",
+      category: "Rails backend" },
+    { path: "app/controllers/api/base_controller.rb",        label: "Api::BaseController",
+      blurb: "JSON-everything error handling so the client always gets a parseable response",
+      category: "Rails backend" },
+    { path: "app/controllers/api/scores_controller.rb",      label: "Scores API",
+      blurb: "GET/POST /api/scores — the endpoint every game hits to save high scores",
+      category: "Rails backend" },
+    { path: "app/channels/controller_channel.rb",            label: "Controller channel",
+      blurb: "The ActionCable channel that routes phone inputs to the TV in real time",
+      category: "Rails backend" },
+    { path: "app/controllers/rooms_controller.rb",           label: "Rooms controller",
+      blurb: "Create a room, join it from a phone, pick a game, start it on the TV",
+      category: "Rails backend" }
+  ].freeze
+
+  def index
+    @grouped = CURATED.group_by { |entry| entry[:category] }
+    @github_repo = "jaykilleen/easy-az"
+  end
+
+  def show
+    path = params[:path].to_s
+    entry = CURATED.find { |e| e[:path] == path }
+
+    raise ActionController::RoutingError, "Not in the code inspector" unless entry
+
+    full_path = Rails.root.join(entry[:path])
+    raise ActionController::RoutingError, "File moved" unless File.exist?(full_path)
+
+    @entry       = entry
+    @source      = File.read(full_path)
+    @github_repo = "jaykilleen/easy-az"
+    @github_url  = "https://github.com/#{@github_repo}/blob/main/#{entry[:path]}"
+    @language    = language_for(entry[:path])
+  end
+
+  private
+
+  def language_for(path)
+    case File.extname(path)
+    when ".rb"    then "ruby"
+    when ".html", ".html.erb", ".erb" then "markup"
+    when ".js"    then "javascript"
+    when ".json"  then "json"
+    when ".css"   then "css"
+    when ".yml", ".yaml" then "yaml"
+    else "plaintext"
+    end
+  end
+end

--- a/app/views/code/index.html.erb
+++ b/app/views/code/index.html.erb
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Source Code — EZ-AZ</title>
+  <meta name="theme-color" content="#0a0a12">
+  <style>
+    *,*::before,*::after { box-sizing: border-box; }
+    html,body { margin: 0; background: #0a0a12; color: #cfe;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    a { color: #00ffc8; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .page { max-width: 900px; margin: 0 auto; padding: 24px 20px 60px; }
+    header { margin-bottom: 24px; }
+    h1 { font-size: clamp(1.8rem, 3vw, 2.4rem); margin: 0 0 8px;
+         background: linear-gradient(135deg, #00ffc8, #00a3ff, #ff00aa);
+         -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .intro { color: #8ab4c8; font-size: 15px; line-height: 1.6; max-width: 660px; }
+    .gh { margin-top: 12px; font-size: 13px; }
+    .gh a { color: #00ffc8; }
+
+    h2 { font-size: 18px; color: #fff; margin: 28px 0 12px;
+         padding-bottom: 6px; border-bottom: 1px solid rgba(0,255,200,0.12); }
+    .files { display: grid; gap: 10px; }
+    .file-card {
+      display: block; background: #13131f; border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 8px; padding: 12px 16px; transition: border-color 200ms, box-shadow 200ms;
+    }
+    .file-card:hover { border-color: #00ffc8; box-shadow: 0 0 20px rgba(0,255,200,0.15);
+                       text-decoration: none; }
+    .file-label { font-weight: 700; color: #fff; font-size: 15px; }
+    .file-path { font-family: "SF Mono", Menlo, monospace; font-size: 11px; color: #667; margin-top: 2px; }
+    .file-blurb { font-size: 13px; color: #8ab4c8; margin-top: 4px; line-height: 1.4; }
+
+    footer { margin-top: 40px; text-align: center; color: #556; font-size: 12px; }
+    footer a { color: #8ab4c8; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <h1>Under the hood</h1>
+      <p class="intro">
+        This is real code that runs EZ-AZ right now. Every game, every API, every
+        touch control — it's all here. Click a file to read the code, see how it
+        works, and maybe learn a trick or two.
+      </p>
+      <p class="gh">
+        Full source on <a href="https://github.com/<%= @github_repo %>" target="_blank">GitHub</a>
+      </p>
+    </header>
+
+    <% @grouped.each do |category, entries| %>
+      <h2><%= category %></h2>
+      <div class="files">
+        <% entries.each do |entry| %>
+          <a class="file-card" href="<%= code_view_path(path: entry[:path]) %>">
+            <div class="file-label"><%= entry[:label] %></div>
+            <div class="file-path"><%= entry[:path] %></div>
+            <div class="file-blurb"><%= entry[:blurb] %></div>
+          </a>
+        <% end %>
+      </div>
+    <% end %>
+
+    <footer>
+      <a href="/">&larr; Back to EZ-AZ</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/app/views/code/show.html.erb
+++ b/app/views/code/show.html.erb
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><%= @entry[:label] %> — Source Code — EZ-AZ</title>
+  <meta name="theme-color" content="#0a0a12">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
+  <style>
+    *,*::before,*::after { box-sizing: border-box; }
+    html,body { margin: 0; background: #0a0a12; color: #cfe;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    a { color: #00ffc8; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .page { max-width: 1200px; margin: 0 auto; padding: 16px 20px 60px; }
+    .breadcrumb { font-size: 13px; color: #667; margin-bottom: 16px; }
+    .breadcrumb a { color: #8ab4c8; }
+
+    h1 { font-size: clamp(1.2rem, 2vw, 1.6rem); margin: 0 0 4px; color: #fff; }
+    .meta { display: flex; align-items: center; gap: 16px; font-size: 12px; color: #8ab4c8; margin-bottom: 16px; }
+    .meta .path { font-family: "SF Mono", Menlo, monospace; color: #667; }
+    .meta a { font-size: 12px; }
+
+    .blurb { font-size: 14px; color: #8ab4c8; line-height: 1.5; margin-bottom: 16px; max-width: 720px; }
+
+    pre[class*="language-"] {
+      background: #13131f !important;
+      border: 1px solid rgba(0,255,200,0.08);
+      border-radius: 8px;
+      font-size: 12px !important;
+      line-height: 1.5;
+      overflow-x: auto;
+      max-height: 80vh;
+    }
+    code[class*="language-"] { font-family: "SF Mono", Menlo, Consolas, monospace; }
+    .line-numbers .line-numbers-rows {
+      border-right-color: rgba(255,255,255,0.06) !important;
+    }
+    .line-numbers-rows > span::before { color: #334 !important; }
+
+    footer { margin-top: 24px; text-align: center; color: #556; font-size: 12px; }
+    footer a { color: #8ab4c8; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="breadcrumb">
+      <a href="/code">All files</a> &rsaquo;
+      <a href="/code?category=<%= ERB::Util.url_encode(@entry[:category]) %>"><%= @entry[:category] %></a> &rsaquo;
+      <span><%= @entry[:label] %></span>
+    </div>
+
+    <h1><%= @entry[:label] %></h1>
+    <div class="meta">
+      <span class="path"><%= @entry[:path] %></span>
+      <a href="<%= @github_url %>" target="_blank">View on GitHub &rarr;</a>
+    </div>
+
+    <p class="blurb"><%= @entry[:blurb] %></p>
+
+    <pre class="line-numbers"><code class="language-<%= @language %>"><%= ERB::Util.html_escape(@source) %></code></pre>
+
+    <footer>
+      <a href="/code">&larr; All files</a>
+      &nbsp;·&nbsp;
+      <a href="/">&larr; Back to EZ-AZ</a>
+    </footer>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-ruby.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
 
   get "/errors", to: "errors_dashboard#index"
 
+  get "/code",     to: "code#index"
+  get "/code/view", to: "code#show"
+
   match "/404", to: "errors#not_found",       via: :all
   match "/500", to: "errors#internal_error",  via: :all
 end

--- a/test/controllers/code_controller_test.rb
+++ b/test/controllers/code_controller_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class CodeControllerTest < ActionDispatch::IntegrationTest
+  test "GET /code returns 200 and lists curated files" do
+    get "/code"
+    assert_response :success
+    assert_includes response.body, "Under the hood"
+    assert_includes response.body, "Space Dodge"
+    assert_includes response.body, "Score model"
+    assert_includes response.body, "Touch controls"
+  end
+
+  test "GET /code groups files by category" do
+    get "/code"
+    %w[Games Store\ frontend Rails\ backend].each do |cat|
+      assert_includes response.body, cat, "missing category: #{cat}"
+    end
+  end
+
+  test "GET /code/view serves a whitelisted file" do
+    get "/code/view", params: { path: "config/routes.rb" }
+    assert_response :success
+    assert_includes response.body, "routes.rb"
+    assert_includes response.body, "Rails.application.routes.draw"
+    assert_includes response.body, "View on GitHub"
+  end
+
+  test "GET /code/view serves a game file" do
+    get "/code/view", params: { path: "public/games/bloom.html" }
+    assert_response :success
+    assert_includes response.body, "Bloom"
+    assert_match(/language-markup/, response.body)
+  end
+
+  test "GET /code/view 404s on non-whitelisted paths" do
+    get "/code/view", params: { path: "config/database.yml" }
+    assert_response :not_found
+  end
+
+  test "GET /code/view 404s on path traversal attempts" do
+    get "/code/view", params: { path: "../../etc/passwd" }
+    assert_response :not_found
+  end
+
+  test "GET /code/view 404s when no path is provided" do
+    get "/code/view"
+    assert_response :not_found
+  end
+
+  test "every curated entry maps to a real file on disk" do
+    CodeController::CURATED.each do |entry|
+      assert File.exist?(Rails.root.join(entry[:path])),
+        "curated file missing from disk: #{entry[:path]}"
+    end
+  end
+
+  test "every curated entry has required fields" do
+    CodeController::CURATED.each do |entry|
+      assert entry[:path].present?,     "missing :path in #{entry.inspect}"
+      assert entry[:label].present?,    "missing :label in #{entry.inspect}"
+      assert entry[:blurb].present?,    "missing :blurb in #{entry.inspect}"
+      assert entry[:category].present?, "missing :category in #{entry.inspect}"
+    end
+  end
+
+  test "source code is HTML-escaped in the viewer" do
+    get "/code/view", params: { path: "public/games/bloom.html" }
+    # HTML tags in the source must be escaped so they render as visible
+    # code, not as live HTML elements.
+    refute_match(/<canvas id="game">/, response.body)
+    assert_match(/&lt;canvas/, response.body)
+  end
+end


### PR DESCRIPTION
Closes jaykilleen/easy-az#34.

A public code inspector at `/code` that lets kids read the actual code running EZ-AZ — games, controllers, channels, everything — with syntax highlighting and line numbers.

### What ships
- **`/code`** — curated file list grouped by category (Games, Store frontend, Rails backend), with labels and blurbs explaining what each file does
- **`/code/view?path=...`** — file viewer with Prism.js syntax highlighting, line numbers, breadcrumbs, and "View on GitHub" link
- **Whitelist-only security** — only the 20 paths in `CodeController::CURATED` are ever served; arbitrary paths (including `../../etc/passwd`) return 404

### Tests
- Index renders categories and file labels
- Show serves whitelisted files with correct syntax class
- Show 404s on non-whitelisted paths and traversal attempts
- Source is HTML-escaped (tags display as code, not live HTML)
- Every CURATED entry has required fields and maps to a real file on disk
- **224 runs, 823 assertions, 0 failures**