### PR TITLE
Add Learning Center at /learn with 11 curated channels

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -1,0 +1,6 @@
+class LearnController < ApplicationController
+  def show
+    @channels   = LearningChannel.all
+    @categories = LearningChannel.categories
+  end
+end

--- a/app/models/learning_channel.rb
+++ b/app/models/learning_channel.rb
@@ -1,0 +1,149 @@
+class LearningChannel
+  CHANNELS = [
+    {
+      slug:        "learn-to-code",
+      title:       "Learn to Code",
+      category:    "coding",
+      emoji:       "💻",
+      description: "Start here. Build your first programs, then level up to real languages.",
+      links: [
+        { label: "Scratch",   url: "https://scratch.mit.edu",        note: "Drag and drop — make games, animations and stories" },
+        { label: "Code.org",  url: "https://studio.code.org",        note: "Hour of Code and full beginner courses" },
+        { label: "CS50",      url: "https://cs50.harvard.edu/x",     note: "Harvard's free intro to programming" }
+      ]
+    },
+    {
+      slug:        "game-design",
+      title:       "Game Design Fundamentals",
+      category:    "game-design",
+      emoji:       "🎮",
+      description: "Why do games feel fun? Learn to design levels, mechanics and player experiences.",
+      links: [
+        { label: "GDC Talks",       url: "https://www.youtube.com/@GDC",           note: "Real game dev talks from the pros" },
+        { label: "Extra Credits",   url: "https://www.youtube.com/@ExtraCredits",  note: "Game design theory for humans" },
+        { label: "Game Maker's Toolkit", url: "https://www.youtube.com/@GMTK",    note: "Deep dives into what makes games tick" }
+      ]
+    },
+    {
+      slug:        "storytelling",
+      title:       "Storytelling for Games",
+      category:    "game-design",
+      emoji:       "📖",
+      description: "Every great game has a story. Learn to write characters, worlds and quests.",
+      links: [
+        { label: "Extra Credits: Story", url: "https://www.youtube.com/playlist?list=PLB9B0CA00461BB187", note: "Narrative design for games" },
+        { label: "Brandon Sanderson", url: "https://www.youtube.com/@BrandonSandersonAuthor", note: "Free uni lectures on writing" }
+      ]
+    },
+    {
+      slug:        "pixel-art",
+      title:       "Art and Pixel Art",
+      category:    "art",
+      emoji:       "🎨",
+      description: "Draw the characters and worlds in your games. No art experience needed.",
+      links: [
+        { label: "Pixel Pete",   url: "https://www.youtube.com/@PixelPete",        note: "Pixel art tutorials from scratch" },
+        { label: "Lospec",       url: "https://lospec.com",                         note: "Free pixel art tools, palettes and tutorials" },
+        { label: "Piskel",       url: "https://www.piskelapp.com",                  note: "Free online pixel art and animation editor" }
+      ]
+    },
+    {
+      slug:        "sound-design",
+      title:       "Sound Design and Music",
+      category:    "art",
+      emoji:       "🎵",
+      description: "Make bleeps, bloops and bangers. Sound brings games to life.",
+      links: [
+        { label: "BFXR",       url: "https://www.bfxr.net",                        note: "Make 8-bit sound effects in your browser" },
+        { label: "BeepBox",    url: "https://www.beepbox.co",                      note: "Compose chiptune music online for free" },
+        { label: "Chrome Music Lab", url: "https://musiclab.chromeexperiments.com", note: "Google's interactive music playground" }
+      ]
+    },
+    {
+      slug:        "math-physics",
+      title:       "Maths and Physics in Games",
+      category:    "science",
+      emoji:       "📐",
+      description: "Collision detection, gravity, vectors — the maths that powers every game.",
+      links: [
+        { label: "3Blue1Brown",  url: "https://www.youtube.com/@3blue1brown",      note: "Maths visualised beautifully" },
+        { label: "Khan Academy", url: "https://www.khanacademy.org/math",           note: "Free maths courses at every level" },
+        { label: "The Coding Train", url: "https://thecodingtrain.com",            note: "Physics sims and creative coding" }
+      ]
+    },
+    {
+      slug:        "how-ai-works",
+      title:       "How AI Works",
+      category:    "science",
+      emoji:       "🤖",
+      description: "What is AI really? How do the tools you use actually think?",
+      links: [
+        { label: "3B1B: Neural Nets", url: "https://www.youtube.com/playlist?list=PLZHQObOWTQDNU6R1_67000Dx_ZCJB-3pi", note: "Best visual explanation of neural networks" },
+        { label: "ML for Kids",       url: "https://machinelearningforkids.co.uk", note: "Train your own AI models" },
+        { label: "Google Teachable Machine", url: "https://teachablemachine.withgoogle.com", note: "Train image and sound AI in the browser" }
+      ]
+    },
+    {
+      slug:        "cryptography",
+      title:       "Cryptography and Secret Codes",
+      category:    "science",
+      emoji:       "🔐",
+      description: "From Caesar ciphers to the maths that keeps the internet safe.",
+      links: [
+        { label: "Art of the Problem", url: "https://www.youtube.com/@ArtOfTheProblem", note: "Beautiful explainers on crypto and information theory" },
+        { label: "Khan: Cryptography", url: "https://www.khanacademy.org/computing/computer-science/cryptography", note: "Free crypto course" }
+      ]
+    },
+    {
+      slug:        "coding-history",
+      title:       "Coding History",
+      category:    "history",
+      emoji:       "🕹️",
+      description: "Ada Lovelace to the iPhone — the wild story of how computing got here.",
+      links: [
+        { label: "Crash Course CS",   url: "https://www.youtube.com/playlist?list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo", note: "40 episodes from punch cards to AI" },
+        { label: "Computer History Museum", url: "https://computerhistory.org", note: "Stories from the people who built computing" }
+      ]
+    },
+    {
+      slug:        "cyber-safety",
+      title:       "Cyber Safety and Online Security",
+      category:    "safety",
+      emoji:       "🛡️",
+      description: "Stay safe online. Passwords, privacy, phishing — what every kid should know.",
+      links: [
+        { label: "Be Internet Awesome", url: "https://beinternetawesome.withgoogle.com", note: "Google's interactive safety game for kids" },
+        { label: "Cyber.org",           url: "https://cyber.org/students",               note: "Cybersecurity learning for students" }
+      ]
+    },
+    {
+      slug:        "setup-computer",
+      title:       "Setting Up Your Coding Computer",
+      category:    "coding",
+      emoji:       "🖥️",
+      description: "Install the tools, set up your editor, and get ready to build real things.",
+      links: [
+        { label: "VS Code",       url: "https://code.visualstudio.com",             note: "Free code editor used by millions of developers" },
+        { label: "GitHub",        url: "https://github.com",                         note: "Where coders save and share their work" },
+        { label: "The Odin Project", url: "https://www.theodinproject.com",         note: "Free full-stack web dev curriculum" }
+      ]
+    }
+  ].freeze
+
+  CATEGORIES = {
+    "coding"      => { label: "Coding",       colour: "#00ffc8" },
+    "game-design" => { label: "Game Design",  colour: "#ff6ec7" },
+    "art"         => { label: "Art & Sound",  colour: "#ffe44d" },
+    "science"     => { label: "Science",      colour: "#4af" },
+    "history"     => { label: "History",      colour: "#fa0" },
+    "safety"      => { label: "Safety",       colour: "#6f6" }
+  }.freeze
+
+  def self.all
+    CHANNELS
+  end
+
+  def self.categories
+    CATEGORIES
+  end
+end

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -1,0 +1,396 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0a0a12">
+  <title>Learning Center — EZ-AZ</title>
+  <link rel="icon" type="image/png" href="/icons/icon-192.png">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:      #0a0a12;
+      --surface: #13131f;
+      --border:  rgba(255,255,255,0.08);
+      --teal:    #00ffc8;
+      --pink:    #ff6ec7;
+      --yellow:  #ffe44d;
+      --text:    #e0e0e0;
+      --muted:   #8ab4c8;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+    }
+
+    /* ---- Header ---- */
+    .lc-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 20px 24px;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+
+    .lc-brand {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+      text-decoration: none;
+    }
+
+    .lc-logo {
+      font-size: clamp(1.4rem, 4vw, 2rem);
+      font-weight: 900;
+      background: linear-gradient(135deg, var(--teal), #00a3ff, var(--pink));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      letter-spacing: -0.03em;
+    }
+
+    .lc-title {
+      font-size: clamp(0.85rem, 2vw, 1rem);
+      color: var(--muted);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .lc-back {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      border: 2px solid var(--border);
+      border-radius: 8px;
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: border-color 0.15s, color 0.15s;
+      white-space: nowrap;
+    }
+
+    .lc-back:hover, .lc-back:focus {
+      border-color: var(--teal);
+      color: var(--teal);
+      outline: none;
+    }
+
+    /* ---- Intro ---- */
+    .lc-intro {
+      padding: 32px 24px 0;
+      max-width: 720px;
+      margin: 0 auto;
+      text-align: center;
+    }
+
+    .lc-intro h1 {
+      font-size: clamp(1.6rem, 5vw, 2.4rem);
+      font-weight: 900;
+      color: #fff;
+      letter-spacing: -0.02em;
+      margin-bottom: 12px;
+    }
+
+    .lc-intro h1 span {
+      background: linear-gradient(90deg, var(--teal), var(--pink));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+
+    .lc-intro p {
+      color: var(--muted);
+      font-size: clamp(0.95rem, 2vw, 1.1rem);
+      line-height: 1.7;
+    }
+
+    /* ---- Filter bar ---- */
+    .lc-filters {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      padding: 24px 24px 0;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .lc-filter {
+      padding: 8px 18px;
+      border: 2px solid var(--border);
+      border-radius: 999px;
+      background: transparent;
+      color: var(--muted);
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+      min-height: 44px;
+    }
+
+    .lc-filter:hover, .lc-filter:focus {
+      outline: none;
+      border-color: var(--teal);
+      color: var(--teal);
+    }
+
+    .lc-filter.active {
+      border-color: var(--teal);
+      background: rgba(0,255,200,0.1);
+      color: var(--teal);
+    }
+
+    /* ---- Grid ---- */
+    .lc-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
+      gap: 20px;
+      padding: 24px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    /* ---- Channel card ---- */
+    .lc-card {
+      background: var(--surface);
+      border: 2px solid var(--border);
+      border-radius: 16px;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+    }
+
+    .lc-card:focus-within {
+      border-color: var(--teal);
+      box-shadow: 0 0 0 4px rgba(0,255,200,0.12);
+      transform: translateY(-2px);
+    }
+
+    .lc-card[hidden] { display: none; }
+
+    .lc-card-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+    }
+
+    .lc-emoji {
+      font-size: 2rem;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .lc-card-meta { flex: 1; min-width: 0; }
+
+    .lc-badge {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 6px;
+      background: rgba(255,255,255,0.06);
+    }
+
+    .lc-card-title {
+      font-size: 1.1rem;
+      font-weight: 800;
+      color: #fff;
+      letter-spacing: -0.01em;
+      line-height: 1.2;
+    }
+
+    .lc-card-desc {
+      font-size: 0.9rem;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+
+    /* ---- Links ---- */
+    .lc-links {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: auto;
+    }
+
+    .lc-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-decoration: none;
+      color: var(--text);
+      font-size: 0.88rem;
+      transition: border-color 0.15s, background 0.15s;
+      min-height: 48px;
+    }
+
+    .lc-link:hover, .lc-link:focus {
+      border-color: rgba(255,255,255,0.25);
+      background: rgba(255,255,255,0.04);
+      outline: none;
+    }
+
+    .lc-link-label {
+      font-weight: 700;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .lc-link-note {
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.3;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .lc-link-arrow {
+      margin-left: auto;
+      color: var(--muted);
+      flex-shrink: 0;
+      font-size: 0.9rem;
+    }
+
+    /* ---- Footer ---- */
+    .lc-footer {
+      text-align: center;
+      padding: 40px 24px;
+      color: #555;
+      font-size: 0.85rem;
+      line-height: 1.8;
+      border-top: 1px solid var(--border);
+      margin-top: 20px;
+    }
+
+    .lc-footer a { color: var(--teal); text-decoration: none; }
+    .lc-footer a:hover { text-decoration: underline; }
+
+    /* ---- TV / large screen tweaks ---- */
+    @media (min-width: 1200px) {
+      .lc-grid { grid-template-columns: repeat(3, 1fr); }
+    }
+
+    @media (min-width: 1600px) {
+      .lc-card { padding: 32px; }
+      .lc-card-title { font-size: 1.3rem; }
+      .lc-link { padding: 14px 18px; font-size: 1rem; min-height: 56px; }
+      .lc-emoji { font-size: 2.5rem; }
+      .lc-badge { font-size: 0.82rem; }
+    }
+
+    /* ---- Focus-visible for TV remote navigation ---- */
+    @media (any-pointer: coarse), (min-width: 960px) {
+      .lc-link:focus {
+        border-color: var(--teal);
+        box-shadow: 0 0 0 3px rgba(0,255,200,0.3);
+        background: rgba(0,255,200,0.06);
+        color: #fff;
+      }
+      .lc-filter:focus {
+        box-shadow: 0 0 0 3px rgba(0,255,200,0.3);
+      }
+    }
+  </style>
+</head>
+<body>
+
+<header class="lc-header">
+  <a href="/" class="lc-brand">
+    <span class="lc-logo">EZ-AZ</span>
+    <span class="lc-title">Learning Center</span>
+  </a>
+  <nav style="display:flex;gap:8px;flex-wrap:wrap;">
+    <a href="/" class="lc-back">&#8592; Games</a>
+    <a href="/prompt.html" class="lc-back">🤖 Build a Game</a>
+  </nav>
+</header>
+
+<section class="lc-intro">
+  <h1>Learn to <span>Build Games</span></h1>
+  <p>
+    Coding, game design, art, music, maths, safety — everything you need to go from player to maker.
+    All free. All hand-picked for kids and families.
+  </p>
+</section>
+
+<div class="lc-filters" role="group" aria-label="Filter by category">
+  <button class="lc-filter active" data-filter="all">All</button>
+  <% @categories.each do |slug, cat| %>
+    <button class="lc-filter" data-filter="<%= slug %>" style="--cat-colour:<%= cat[:colour] %>">
+      <%= cat[:label] %>
+    </button>
+  <% end %>
+</div>
+
+<div class="lc-grid" id="lc-grid">
+  <% @channels.each do |ch| %>
+    <% cat = @categories[ch[:category]] %>
+    <div class="lc-card" data-category="<%= ch[:category] %>">
+      <div class="lc-card-header">
+        <div class="lc-emoji" aria-hidden="true"><%= ch[:emoji] %></div>
+        <div class="lc-card-meta">
+          <span class="lc-badge" style="color:<%= cat[:colour] %>;border:1px solid <%= cat[:colour] %>33">
+            <%= cat[:label] %>
+          </span>
+          <div class="lc-card-title"><%= ch[:title] %></div>
+        </div>
+      </div>
+      <p class="lc-card-desc"><%= ch[:description] %></p>
+      <div class="lc-links">
+        <% ch[:links].each do |link| %>
+          <a class="lc-link" href="<%= link[:url] %>" target="_blank" rel="noopener noreferrer">
+            <span class="lc-link-label"><%= link[:label] %></span>
+            <span class="lc-link-note"><%= link[:note] %></span>
+            <span class="lc-link-arrow" aria-hidden="true">&#8599;</span>
+          </a>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<footer class="lc-footer">
+  Built by Charlie and Cooper (aged 8), with their friend Jay helping them learn to work with AI.<br>
+  Gumdale's first family friendly video game store.<br>
+  <a href="/">EZ-AZ</a>
+</footer>
+
+<script>
+  (function() {
+    var filters  = document.querySelectorAll('.lc-filter');
+    var cards    = document.querySelectorAll('.lc-card');
+    var current  = 'all';
+
+    filters.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        current = btn.getAttribute('data-filter');
+        filters.forEach(function(b) { b.classList.toggle('active', b === btn); });
+        cards.forEach(function(card) {
+          var match = current === 'all' || card.getAttribute('data-category') === current;
+          card.hidden = !match;
+        });
+      });
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/app/views/tv/show.html.erb
+++ b/app/views/tv/show.html.erb
@@ -221,6 +221,29 @@
     font-family: "Courier New", monospace;
   }
 
+  .tv-learn-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6vw;
+    padding: 0.8vh 1.4vw;
+    background: rgba(0, 255, 200, 0.08);
+    border: 2px solid rgba(0, 255, 200, 0.35);
+    border-radius: 0.8vw;
+    color: #00ffc8;
+    text-decoration: none;
+    font-size: clamp(0.9rem, 1.2vw, 1.3rem);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  }
+
+  .tv-learn-btn:focus, .tv-learn-btn:hover {
+    background: rgba(0, 255, 200, 0.18);
+    border-color: #00ffc8;
+    box-shadow: 0 0 0 4px rgba(0,255,200,0.2);
+    outline: none;
+  }
+
   .tv-status {
     font-size: clamp(0.85rem, 1.1vw, 1.1rem);
     color: #667;
@@ -305,6 +328,9 @@
   </section>
 
   <footer class="tv-footer">
+    <a href="/learn" class="tv-learn-btn" id="tv-learn-btn">
+      📚 Learning Center
+    </a>
     <div class="tv-hint">
       <span class="tv-key">&larr;</span>
       <span class="tv-key">&rarr;</span>
@@ -320,19 +346,30 @@
 
 <script>
   (function() {
-    var shelf = document.getElementById('tv-shelf');
-    var games = Array.prototype.slice.call(shelf.querySelectorAll('.tv-game'));
+    var shelf    = document.getElementById('tv-shelf');
+    var games    = Array.prototype.slice.call(shelf.querySelectorAll('.tv-game'));
+    var learnBtn = document.getElementById('tv-learn-btn');
     var focusedIndex = 0;
+    var learnFocused = false;
 
-    function focus(index) {
+    function focusGame(index) {
       index = Math.max(0, Math.min(games.length - 1, index));
       games.forEach(function(g, i) {
         g.tabIndex = i === index ? 0 : -1;
         g.classList.toggle('is-focused', i === index);
       });
+      learnBtn.tabIndex = -1;
+      learnFocused = false;
       focusedIndex = index;
       games[index].focus();
       scrollIntoView(games[index]);
+    }
+
+    function focusLearn() {
+      games.forEach(function(g) { g.tabIndex = -1; g.classList.remove('is-focused'); });
+      learnBtn.tabIndex = 0;
+      learnFocused = true;
+      learnBtn.focus();
     }
 
     function scrollIntoView(el) {
@@ -347,21 +384,34 @@
       switch (e.key) {
         case 'ArrowLeft':
           e.preventDefault();
-          focus(focusedIndex - 1);
+          if (learnFocused) { focusGame(games.length - 1); }
+          else { focusGame(focusedIndex - 1); }
           break;
         case 'ArrowRight':
           e.preventDefault();
-          focus(focusedIndex + 1);
+          if (learnFocused) break;
+          if (focusedIndex === games.length - 1) { focusLearn(); }
+          else { focusGame(focusedIndex + 1); }
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          focusLearn();
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          if (learnFocused) focusGame(focusedIndex);
           break;
         case 'Enter':
         case ' ':
           e.preventDefault();
-          games[focusedIndex].click();
+          if (learnFocused) { learnBtn.click(); }
+          else { games[focusedIndex].click(); }
           break;
       }
     });
 
     // Initialize focus
-    focus(0);
+    learnBtn.tabIndex = -1;
+    focusGame(0);
   })();
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   mount ActionCable.server => "/cable"
 
-  get "/tv", to: "tv#show"
+  get "/tv",    to: "tv#show"
+  get "/learn", to: "learn#show"
 
   resources :rooms, only: [:new, :create, :show], param: :code do
     member do

--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,32 @@
       text-transform: uppercase;
     }
 
+    .store-nav {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 16px;
+    }
+
+    .store-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 18px;
+      border: 2px solid rgba(255,255,255,0.12);
+      border-radius: 999px;
+      color: #aaa;
+      font-size: 13px;
+      font-weight: 600;
+      text-decoration: none;
+      letter-spacing: 0.04em;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .store-nav a:hover { border-color: #00ffc8; color: #00ffc8; }
+    .store-nav a.active { border-color: #00ffc8; color: #00ffc8; background: rgba(0,255,200,0.06); }
+
     .store-version {
       font-size: 11px;
       color: #555;
@@ -938,6 +964,11 @@
     <h1 class="store-name">EZ-AZ</h1>
     <p class="store-tagline">The Family Video Game Store</p>
     <p class="store-version" id="storeVersion"></p>
+    <nav class="store-nav">
+      <a href="/" class="active">🎮 Games</a>
+      <a href="/learn">📚 Learning Center</a>
+      <a href="/prompt.html">🤖 Build a Game</a>
+    </nav>
   </header>
 
   <!-- Auth modal -->
@@ -1232,7 +1263,7 @@
   <footer class="store-footer">
     Built by Cooper and Charlie (aged 8), with Jay helping them learn to work with AI.<br>
     Gumdale's first family friendly video game store. Launched 28th February 2026.<br>
-    <a href="/licence.html">Licence</a>
+    <a href="/learn">Learning Center</a> &middot; <a href="/licence.html">Licence</a>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary

- Closes #36 — fully mobile-responsive Learning Center (single column on phones, 2-col tablets, 3-col desktop, large-text TV mode)
- Closes #37 — Android TV wrapper picks this up automatically via WebView; D-pad can navigate down from the game shelf to the Learning Center button; BACK returns to `/tv`

## What's built

**`/learn`** — a new page with 11 curated channel groups:

| Category | Channels |
|---|---|
| Coding | Learn to Code, Setting Up Your Computer |
| Game Design | Game Design Fundamentals, Storytelling |
| Art & Sound | Pixel Art, Sound Design |
| Science | Maths & Physics, How AI Works, Cryptography |
| History | Coding History |
| Safety | Cyber Safety |

Each card links to 2–3 real free resources (Scratch, Code.org, GDC, 3Blue1Brown, Khan Academy, etc.). Category filter bar lets kids jump straight to what interests them.

**TV page** — added a 📚 Learning Center button in the footer. D-pad: ArrowDown from shelf focuses it, ArrowRight from last game also reaches it, Enter navigates to `/learn`.

**No Android TV app changes** — the wrapper's WebView already allows all `ez-az.net` URLs and handles back navigation through history, so `/learn` just works.

## Test plan
- [ ] `/learn` loads on mobile — single column, tap targets comfortable
- [ ] `/learn` loads on tablet — 2–3 column grid
- [ ] Category filter buttons hide/show cards correctly
- [ ] All external links open in new tab
- [ ] `/tv` shows Learning Center button in footer
- [ ] D-pad: ArrowDown from game shelf → Learning Center button focuses
- [ ] D-pad: Enter on Learning Center → navigates to `/learn`
- [ ] D-pad: BACK on `/learn` → returns to `/tv` (WebView history)
- [ ] Large screen (1600px+) renders with bigger text/buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)