### PR TITLE
Design system: shared ez-az-shell.css applied to Dino Jump, Golden Goal, Snake Pit Royale

### DIFF
--- a/app/views/dino_jump/join.html.erb
+++ b/app/views/dino_jump/join.html.erb
@@ -4,29 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Dino Jump — Controller</title>
+  <link rel="stylesheet" href="/ez-az-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body {
       width: 100%; height: 100%;
       background: #080810;
       color: #fff;
-      font-family: 'Courier New', monospace;
+      font-family: var(--ez-font);
       overflow: hidden;
       touch-action: none;
       user-select: none;
       -webkit-user-select: none;
     }
-
-    .store-banner {
-      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-      background: rgba(8,8,16,0.92);
-      border-bottom: 1px solid rgba(255,255,255,0.06);
-      padding: 10px 16px;
-      text-align: center;
-      font-size: 13px;
-      letter-spacing: 0.1em;
-    }
-    .store-banner a { color: #ffe44d; text-decoration: none; font-weight: 700; }
 
     .page {
       padding-top: 44px;
@@ -54,69 +44,15 @@
       letter-spacing: 0.12em;
       color: #ffe44d;
       text-align: center;
+      text-shadow: 0 0 12px rgba(255,228,77,0.5);
     }
     .game-sub { font-size: 12px; color: #556; text-align: center; letter-spacing: 0.08em; }
-    .label { font-size: 11px; color: #778; letter-spacing: 0.1em; text-transform: uppercase; }
-    .name-input {
-      width: 100%;
-      background: #13131f;
-      border: 1px solid rgba(255,255,255,0.1);
-      border-radius: 8px;
-      padding: 14px 16px;
-      font-family: 'Courier New', monospace;
-      font-size: 18px;
-      font-weight: 700;
-      color: #fff;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      outline: none;
-    }
-    .name-input:focus { border-color: #ffe44d; }
-    .name-input::placeholder { color: #334; }
-    .btn {
-      width: 100%;
-      padding: 16px;
-      border: none;
-      border-radius: 10px;
-      font-family: 'Courier New', monospace;
-      font-size: 16px;
-      font-weight: 700;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      cursor: pointer;
-      background: #ffe44d;
-      color: #111;
-    }
-    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
-    .error-msg { color: #ff4757; font-size: 12px; text-align: center; min-height: 16px; }
+
+    /* Yellow accent for name input on this game */
+    .ezaz-name-input:focus { border-color: #ffe44d; }
 
     /* ---- Lobby screen ---- */
-    .lobby-inner {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      gap: 20px;
-      padding: 20px;
-    }
-    .char-badge {
-      width: 120px;
-      height: 120px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 48px;
-      border: 4px solid rgba(255,255,255,0.3);
-    }
-    .char-name-big {
-      font-size: 28px;
-      font-weight: 900;
-      letter-spacing: 0.15em;
-      font-family: 'Courier New', monospace;
-    }
-    .waiting-text { font-size: 13px; color: #556; letter-spacing: 0.08em; text-align: center; }
+    .char-badge { background: #080810; }
 
     /* ---- Controller screen ---- */
     .controller {
@@ -156,40 +92,16 @@
       border: 3px solid rgba(255,255,255,0.15);
     }
     .dir-btn:active, .dir-btn.pressed { filter: brightness(1.3); }
-
-    /* ---- Game over screen ---- */
-    .gameover-inner {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      gap: 16px;
-      padding: 24px 20px;
-      text-align: center;
-    }
-    .go-rank { font-size: 60px; font-weight: 900; }
-    .go-score { font-size: 16px; color: #00ffcc; letter-spacing: 0.08em; }
-    .go-name { font-size: 22px; font-weight: 700; letter-spacing: 0.1em; }
-    .btn-outline {
-      padding: 14px 32px;
-      border: 2px solid rgba(255,255,255,0.2);
-      border-radius: 10px;
-      background: transparent;
-      color: #aaa;
-      font-family: 'Courier New', monospace;
-      font-size: 13px;
-      font-weight: 700;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      cursor: pointer;
-      text-decoration: none;
-      display: block;
-    }
   </style>
 </head>
 <body>
-  <div class="store-banner"><a href="/">EZ-AZ</a></div>
+  <div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
+  <!--
+    Phone Contract 4: EXIT must be reachable from every screen and must free
+    the slot server-side. The button is wired after the cable subscription
+    is created below.
+  -->
+  <button class="ezaz-exit-btn" id="exitBtn">EXIT</button>
 
   <div class="page">
 
@@ -198,22 +110,22 @@
       <div class="join-inner">
         <div class="game-title">DINO JUMP</div>
         <div class="game-sub">Enter your name to join</div>
-        <span class="label">Your name</span>
-        <input class="name-input" id="nameInput" type="text" maxlength="12"
+        <span class="ezaz-label">Your name</span>
+        <input class="ezaz-name-input" id="nameInput" type="text" maxlength="12"
                placeholder="ENTER NAME" autocomplete="off" autocorrect="off"
                autocapitalize="characters" spellcheck="false">
-        <div class="error-msg" id="errorMsg"></div>
-        <button class="btn" id="joinBtn" disabled>JOIN GAME</button>
+        <div class="ezaz-error-msg" id="errorMsg"></div>
+        <button class="ezaz-btn-primary" id="joinBtn" disabled style="--ez-btn-bg:#ffe44d;--ez-btn-fg:#111;">JOIN GAME</button>
       </div>
     </div>
 
     <!-- LOBBY (waiting for start) -->
     <div class="screen" id="screenLobby">
-      <div class="lobby-inner">
+      <div class="ezaz-lobby-inner">
         <div class="game-title">DINO JUMP</div>
-        <div class="char-badge" id="lobbyBadge"></div>
-        <div class="char-name-big" id="lobbyCharName"></div>
-        <div class="waiting-text">Waiting for the host to start...</div>
+        <div class="ezaz-char-badge char-badge" id="lobbyBadge"></div>
+        <div class="ezaz-char-name" id="lobbyCharName"></div>
+        <div class="ezaz-waiting">Waiting for the host to start...</div>
       </div>
     </div>
 
@@ -233,12 +145,12 @@
 
     <!-- GAME OVER -->
     <div class="screen" id="screenOver">
-      <div class="gameover-inner">
+      <div class="ezaz-gameover-inner">
         <div class="game-title">DINO JUMP</div>
-        <div class="go-rank" id="goRank"></div>
-        <div class="go-name" id="goName"></div>
-        <div class="go-score" id="goScore"></div>
-        <a href="/" class="btn-outline">BACK TO STORE</a>
+        <div class="ezaz-go-rank" id="goRank"></div>
+        <div class="ezaz-go-name" id="goName"></div>
+        <div class="ezaz-go-score" id="goScore"></div>
+        <a href="/" class="ezaz-btn-outline">BACK TO STORE</a>
       </div>
     </div>
 
@@ -339,7 +251,7 @@
       document.body.style.background = myChar.bg;
     }
 
-    // ---- AzCable (same pattern as Marble Run) ----
+    // ---- Cable (minimal raw ActionCable WebSocket client) ----
     var wsBase = window.location.origin.replace(/^http/, 'ws') + '/cable';
 
     function AzCable() {
@@ -383,6 +295,12 @@
       { channel: 'DinoJumpChannel', code: code, role: 'phone' },
       { received: onMessage }
     );
+
+    // Phone Contract 4: EXIT frees the slot server-side before going home.
+    document.getElementById('exitBtn').addEventListener('click', function() {
+      if (sub && mySlot !== null) { try { sub.send('leave', {}); } catch (_) {} }
+      setTimeout(function() { window.location.href = '/'; }, 150);
+    });
 
     function onMessage(msg) {
       switch (msg.type) {

--- a/app/views/golden_goal/join.html.erb
+++ b/app/views/golden_goal/join.html.erb
@@ -4,59 +4,40 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Golden Goal — Controller</title>
+  <link rel="stylesheet" href="/ez-az-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body {
       width: 100%; height: 100%;
       background: #04070a; color: #fff;
-      font-family: 'Courier New', monospace;
+      font-family: var(--ez-font);
       overflow: hidden; touch-action: none; user-select: none; -webkit-user-select: none;
     }
-    .store-banner {
-      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-      background: rgba(4,7,10,0.92); border-bottom: 1px solid rgba(255,255,255,0.06);
-      padding: 10px 16px; text-align: center; font-size: 13px; letter-spacing: 0.1em;
-    }
-    .store-banner a { color: #ffd23b; text-decoration: none; font-weight: 700; }
-    .exit-btn {
-      position: fixed; top: 6px; right: 10px; z-index: 101;
-      background: transparent; border: 1px solid rgba(255,71,87,0.5); border-radius: 6px;
-      color: #ff4757; font-family: 'Courier New', monospace; font-size: 11px; font-weight: 700;
-      letter-spacing: 0.1em; padding: 5px 10px; cursor: pointer;
-    }
-    .start-btn {
-      width: 100%; max-width: 280px; padding: 16px; border: none; border-radius: 10px;
-      font-family: 'Courier New', monospace; font-size: 16px; font-weight: 700;
-      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer;
-      background: #ffd23b; color: #171206;
-    }
+
     .page { padding-top: 44px; height: 100%; display: flex; flex-direction: column; align-items: center; }
     .screen { width: 100%; height: 100%; display: none; flex-direction: column; align-items: center; }
     .screen.active { display: flex; }
 
+    /* ---- Join screen ---- */
     .join-inner { max-width: 400px; width: 100%; padding: 24px 20px; display: flex; flex-direction: column; gap: 14px; }
     .game-title { font-size: 23px; font-weight: 900; letter-spacing: 0.1em; color: #ffd23b; text-align: center; text-shadow: 0 0 14px rgba(255,210,59,0.5); }
     .game-sub { font-size: 12px; color: #567; text-align: center; letter-spacing: 0.06em; }
-    .label { font-size: 11px; color: #678; letter-spacing: 0.1em; text-transform: uppercase; }
-    .name-input {
-      width: 100%; background: #14110c; border: 1px solid rgba(255,255,255,0.1); border-radius: 8px;
-      padding: 14px 16px; font-family: 'Courier New', monospace; font-size: 18px; font-weight: 700;
-      color: #fff; text-transform: uppercase; letter-spacing: 0.1em; outline: none;
-    }
-    .name-input:focus { border-color: #ffd23b; }
-    .name-input::placeholder { color: #443; }
-    .btn {
-      width: 100%; padding: 16px; border: none; border-radius: 10px;
-      font-family: 'Courier New', monospace; font-size: 16px; font-weight: 700;
-      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer; background: #ffd23b; color: #14110c;
-    }
-    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
-    .error-msg { color: #ff4757; font-size: 12px; text-align: center; min-height: 16px; }
 
-    .lobby-inner { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 20px; padding: 20px; }
-    .char-badge { width: 120px; height: 120px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 56px; border: 4px solid rgba(255,255,255,0.3); }
-    .char-name-big { font-size: 26px; font-weight: 900; letter-spacing: 0.12em; }
-    .waiting-text { font-size: 13px; color: #567; letter-spacing: 0.06em; text-align: center; line-height: 1.6; }
+    /* Gold accent for name input focus on this game */
+    .ezaz-name-input:focus { border-color: #ffd23b; }
+
+    /* ---- Lobby screen ---- */
+    .char-badge { background: #14110c; }
+
+    /* ---- Start button (host only) ---- */
+    .start-btn {
+      width: 100%; max-width: 280px; padding: 16px; border: none; border-radius: 10px;
+      font-family: var(--ez-font); font-size: 16px; font-weight: 700;
+      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer;
+      background: #ffd23b; color: #171206;
+      transition: transform 0.1s;
+    }
+    .start-btn:hover { transform: scale(1.03); }
 
     /* ---- Pick controller ---- */
     .controller { width: 100%; flex: 1; display: flex; flex-direction: column; }
@@ -113,23 +94,13 @@
     .sb-list { width: 100%; max-width: 320px; }
     .sb-row { display: flex; justify-content: space-between; padding: 7px 12px; font-size: 14px; font-weight: 700; letter-spacing: 0.06em; border-bottom: 1px solid rgba(255,255,255,0.06); }
     .sb-row.me { background: rgba(255,210,59,0.1); border-radius: 6px; }
-
-    .gameover-inner { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 16px; padding: 24px 20px; text-align: center; }
-    .go-rank { font-size: 56px; font-weight: 900; }
-    .go-score { font-size: 16px; color: #ffd23b; letter-spacing: 0.06em; }
-    .go-name { font-size: 22px; font-weight: 700; letter-spacing: 0.1em; }
-    .btn-outline {
-      padding: 14px 32px; border: 2px solid rgba(255,255,255,0.2); border-radius: 10px;
-      background: transparent; color: #aaa; font-family: 'Courier New', monospace; font-size: 13px;
-      font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer; text-decoration: none; display: block;
-    }
   </style>
 </head>
 <body>
-  <div class="store-banner"><a href="/">EZ-AZ</a></div>
+  <div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
   <!-- Phone Contract 4: EXIT is reachable from every screen. It frees the
        slot server-side (leave) before heading back to the store. -->
-  <button class="exit-btn" id="exitBtn">EXIT</button>
+  <button class="ezaz-exit-btn" id="exitBtn">EXIT</button>
 
   <div class="page">
 
@@ -138,22 +109,22 @@
       <div class="join-inner">
         <div class="game-title">GOLDEN GOAL</div>
         <div class="game-sub">Enter your name to step up to the spot</div>
-        <span class="label">Your name</span>
-        <input class="name-input" id="nameInput" type="text" maxlength="12"
+        <span class="ezaz-label">Your name</span>
+        <input class="ezaz-name-input" id="nameInput" type="text" maxlength="12"
                placeholder="ENTER NAME" autocomplete="off" autocorrect="off"
                autocapitalize="characters" spellcheck="false">
-        <div class="error-msg" id="errorMsg"></div>
-        <button class="btn" id="joinBtn" disabled>JOIN GAME</button>
+        <div class="ezaz-error-msg" id="errorMsg"></div>
+        <button class="ezaz-btn-primary" id="joinBtn" disabled style="--ez-btn-bg:#ffd23b;--ez-btn-fg:#14110c;">JOIN GAME</button>
       </div>
     </div>
 
     <!-- LOBBY -->
     <div class="screen" id="screenLobby">
-      <div class="lobby-inner">
+      <div class="ezaz-lobby-inner">
         <div class="game-title">GOLDEN GOAL</div>
-        <div class="char-badge" id="lobbyBadge">&#9917;</div>
-        <div class="char-name-big" id="lobbyCharName"></div>
-        <div class="waiting-text" id="lobbyWaitText">You're in! Waiting for the host to start.</div>
+        <div class="ezaz-char-badge char-badge" id="lobbyBadge">&#9917;</div>
+        <div class="ezaz-char-name" id="lobbyCharName"></div>
+        <div class="ezaz-waiting" id="lobbyWaitText">You're in! Waiting for the host to start.</div>
         <!-- Phone Contract 3: the first joiner is the host and can kick off
              from the couch. Hidden for everyone else. -->
         <button class="start-btn" id="startBtn">KICK OFF</button>
@@ -194,7 +165,7 @@
     <div class="screen" id="screenLocked">
       <div class="locked-inner">
         <div class="locked-big" id="lockedBig"></div>
-        <div class="waiting-text">Look at the TV!</div>
+        <div class="ezaz-waiting">Look at the TV!</div>
       </div>
     </div>
 
@@ -202,21 +173,21 @@
     <div class="screen" id="screenWatch">
       <div class="watch-inner">
         <div class="game-title">GOLDEN GOAL</div>
-        <div class="waiting-text" id="watchLine">Watch the big screen</div>
+        <div class="ezaz-waiting" id="watchLine">Watch the big screen</div>
         <div class="sb-list" id="sbList"></div>
       </div>
     </div>
 
     <!-- GAME OVER -->
     <div class="screen" id="screenOver">
-      <div class="gameover-inner">
+      <div class="ezaz-gameover-inner">
         <div class="game-title">GOLDEN GOAL</div>
-        <div class="go-rank" id="goRank"></div>
-        <div class="go-name" id="goName"></div>
-        <div class="go-score" id="goScore"></div>
-        <div class="waiting-text">Your slot is saved. Stay for the rematch!</div>
-        <button class="btn-outline" id="lobbyAgainBtn">BACK TO LOBBY</button>
-        <button class="btn-outline" id="overExitBtn">BACK TO STORE</button>
+        <div class="ezaz-go-rank" id="goRank"></div>
+        <div class="ezaz-go-name" id="goName"></div>
+        <div class="ezaz-go-score" id="goScore"></div>
+        <div class="ezaz-waiting">Your slot is saved. Stay for the rematch!</div>
+        <button class="ezaz-btn-outline" id="lobbyAgainBtn">BACK TO LOBBY</button>
+        <button class="ezaz-btn-outline" id="overExitBtn">BACK TO STORE</button>
       </div>
     </div>
 

--- a/app/views/snake_pit/join.html.erb
+++ b/app/views/snake_pit/join.html.erb
@@ -4,59 +4,38 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Snake Pit Royale — Controller</title>
+  <link rel="stylesheet" href="/ez-az-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body {
       width: 100%; height: 100%;
       background: #04070a; color: #fff;
-      font-family: 'Courier New', monospace;
+      font-family: var(--ez-font);
       overflow: hidden; touch-action: none; user-select: none; -webkit-user-select: none;
     }
-    .store-banner {
-      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-      background: rgba(4,7,10,0.92); border-bottom: 1px solid rgba(255,255,255,0.06);
-      padding: 10px 16px; text-align: center; font-size: 13px; letter-spacing: 0.1em;
-    }
-    .store-banner a { color: #00ffaa; text-decoration: none; font-weight: 700; }
-    .exit-btn {
-      position: fixed; top: 6px; right: 10px; z-index: 101;
-      background: transparent; border: 1px solid rgba(255,71,87,0.5); border-radius: 6px;
-      color: #ff4757; font-family: 'Courier New', monospace; font-size: 11px; font-weight: 700;
-      letter-spacing: 0.1em; padding: 5px 10px; cursor: pointer;
-    }
-    .start-btn {
-      width: 100%; max-width: 280px; padding: 16px; border: none; border-radius: 10px;
-      font-family: 'Courier New', monospace; font-size: 16px; font-weight: 700;
-      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer;
-      background: #ffd23b; color: #171206;
-    }
+
     .page { padding-top: 44px; height: 100%; display: flex; flex-direction: column; align-items: center; }
     .screen { width: 100%; height: 100%; display: none; flex-direction: column; align-items: center; }
     .screen.active { display: flex; }
 
+    /* ---- Join screen ---- */
     .join-inner { max-width: 400px; width: 100%; padding: 24px 20px; display: flex; flex-direction: column; gap: 14px; }
     .game-title { font-size: 23px; font-weight: 900; letter-spacing: 0.1em; color: #00ffaa; text-align: center; text-shadow: 0 0 14px rgba(0,255,170,0.5); }
     .game-sub { font-size: 12px; color: #567; text-align: center; letter-spacing: 0.06em; }
-    .label { font-size: 11px; color: #678; letter-spacing: 0.1em; text-transform: uppercase; }
-    .name-input {
-      width: 100%; background: #0c1411; border: 1px solid rgba(255,255,255,0.1); border-radius: 8px;
-      padding: 14px 16px; font-family: 'Courier New', monospace; font-size: 18px; font-weight: 700;
-      color: #fff; text-transform: uppercase; letter-spacing: 0.1em; outline: none;
-    }
-    .name-input:focus { border-color: #00ffaa; }
-    .name-input::placeholder { color: #243; }
-    .btn {
-      width: 100%; padding: 16px; border: none; border-radius: 10px;
-      font-family: 'Courier New', monospace; font-size: 16px; font-weight: 700;
-      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer; background: #00ffaa; color: #04140d;
-    }
-    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
-    .error-msg { color: #ff4757; font-size: 12px; text-align: center; min-height: 16px; }
 
-    .lobby-inner { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 20px; padding: 20px; }
-    .char-badge { width: 120px; height: 120px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 56px; border: 4px solid rgba(255,255,255,0.3); }
-    .char-name-big { font-size: 26px; font-weight: 900; letter-spacing: 0.12em; }
-    .waiting-text { font-size: 13px; color: #567; letter-spacing: 0.06em; text-align: center; }
+    /* ---- Lobby screen ---- */
+    .char-badge { background: #04140d; }
+    .char-name-big { color: #00ffaa; }
+
+    /* ---- Start button (host only) ---- */
+    .start-btn {
+      width: 100%; max-width: 280px; padding: 16px; border: none; border-radius: 10px;
+      font-family: var(--ez-font); font-size: 16px; font-weight: 700;
+      letter-spacing: 0.12em; text-transform: uppercase; cursor: pointer;
+      background: #ffd23b; color: #171206;
+      transition: transform 0.1s;
+    }
+    .start-btn:hover { transform: scale(1.03); }
 
     /* ---- D-pad controller ---- */
     .controller { width: 100%; flex: 1; display: flex; flex-direction: column; }
@@ -85,23 +64,13 @@
     .dir-right { grid-column: 3; grid-row: 2; }
     .dir-down  { grid-column: 2; grid-row: 3; }
     .dpad-center { grid-column: 2; grid-row: 2; display: flex; align-items: center; justify-content: center; font-size: 34px; opacity: 0.5; }
-
-    .gameover-inner { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 16px; padding: 24px 20px; text-align: center; }
-    .go-rank { font-size: 56px; font-weight: 900; }
-    .go-score { font-size: 16px; color: #00ffaa; letter-spacing: 0.06em; }
-    .go-name { font-size: 22px; font-weight: 700; letter-spacing: 0.1em; }
-    .btn-outline {
-      padding: 14px 32px; border: 2px solid rgba(255,255,255,0.2); border-radius: 10px;
-      background: transparent; color: #aaa; font-family: 'Courier New', monospace; font-size: 13px;
-      font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer; text-decoration: none; display: block;
-    }
   </style>
 </head>
 <body>
-  <div class="store-banner"><a href="/">EZ-AZ</a></div>
+  <div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
   <!-- Phone Contract 4: EXIT is reachable from every screen. It frees the
        slot server-side (leave) before heading back to the store. -->
-  <button class="exit-btn" id="exitBtn">EXIT</button>
+  <button class="ezaz-exit-btn" id="exitBtn">EXIT</button>
 
   <div class="page">
 
@@ -110,22 +79,22 @@
       <div class="join-inner">
         <div class="game-title">SNAKE PIT ROYALE</div>
         <div class="game-sub">Enter your name to join the pit</div>
-        <span class="label">Your name</span>
-        <input class="name-input" id="nameInput" type="text" maxlength="12"
+        <span class="ezaz-label">Your name</span>
+        <input class="ezaz-name-input" id="nameInput" type="text" maxlength="12"
                placeholder="ENTER NAME" autocomplete="off" autocorrect="off"
                autocapitalize="characters" spellcheck="false">
-        <div class="error-msg" id="errorMsg"></div>
-        <button class="btn" id="joinBtn" disabled>JOIN GAME</button>
+        <div class="ezaz-error-msg" id="errorMsg"></div>
+        <button class="ezaz-btn-primary" id="joinBtn" disabled style="--ez-btn-bg:#00ffaa;--ez-btn-fg:#04140d;">JOIN GAME</button>
       </div>
     </div>
 
     <!-- LOBBY -->
     <div class="screen" id="screenLobby">
-      <div class="lobby-inner">
+      <div class="ezaz-lobby-inner">
         <div class="game-title">SNAKE PIT</div>
-        <div class="char-badge" id="lobbyBadge">🐍</div>
-        <div class="char-name-big" id="lobbyCharName"></div>
-        <div class="waiting-text" id="lobbyWaitText">You're in. Waiting for the host to start...</div>
+        <div class="ezaz-char-badge char-badge" id="lobbyBadge">🐍</div>
+        <div class="ezaz-char-name char-name-big" id="lobbyCharName"></div>
+        <div class="ezaz-waiting" id="lobbyWaitText">You're in. Waiting for the host to start...</div>
         <!-- Phone Contract 3: the first joiner is the host and can start the
              match from the couch. Hidden for everyone else. -->
         <button class="start-btn" id="startBtn">START THE PIT</button>
@@ -153,14 +122,14 @@
 
     <!-- GAME OVER -->
     <div class="screen" id="screenOver">
-      <div class="gameover-inner">
+      <div class="ezaz-gameover-inner">
         <div class="game-title">SNAKE PIT</div>
-        <div class="go-rank" id="goRank"></div>
-        <div class="go-name" id="goName"></div>
-        <div class="go-score" id="goScore"></div>
-        <div class="waiting-text">Your slot is saved. Stay for the rematch!</div>
-        <button class="btn-outline" id="lobbyAgainBtn">BACK TO LOBBY</button>
-        <button class="btn-outline" id="overExitBtn">BACK TO STORE</button>
+        <div class="ezaz-go-rank" id="goRank"></div>
+        <div class="ezaz-go-name" id="goName"></div>
+        <div class="ezaz-go-score" id="goScore"></div>
+        <div class="ezaz-waiting">Your slot is saved. Stay for the rematch!</div>
+        <button class="ezaz-btn-outline" id="lobbyAgainBtn">BACK TO LOBBY</button>
+        <button class="ezaz-btn-outline" id="overExitBtn">BACK TO STORE</button>
       </div>
     </div>
 

--- a/docs/decisions/011-shared-design-system.md
+++ b/docs/decisions/011-shared-design-system.md
@@ -1,0 +1,116 @@
+# ADR 011 — Shared Design System (ez-az-shell.css)
+
+**Status:** Accepted
+**Date:** 12 June 2026
+
+---
+
+## Context
+
+Three of the early party games (Snake Pit Royale, Golden Goal, Dino Jump) each carried their own
+copy of the same visual primitives: store banner, exit button, name input, join button, lobby
+screen, game-over screen, TV QR box, slot cards, leaderboard, and score cards. The copies had
+drifted from each other and from the reference games (Family Trivia, Spotlight, Treasure Hunt)
+in ways that weakened the brand:
+
+1. Store banner links used each game's own accent colour instead of the shared brand gradient.
+2. Game-over "back to store" buttons were near-invisible (`rgba(255,255,255,0.2)` on dark
+   backgrounds).
+3. QR join boxes were tinted with the game's own colour instead of the brand-level teal.
+4. Primary buttons on two games used a gray gradient, giving no visual signal.
+5. Dino Jump's phone join page had no EXIT button, violating Phone Contract clause 4.
+
+A design audit of the reference games extracted a consistent set of tokens and component
+classes. The goal of this ADR is to capture that extraction and the decisions made during it.
+
+---
+
+## Decisions
+
+### 1. Single shared stylesheet: `public/ez-az-shell.css`
+
+All design tokens and shell components live in one file. Games include it with:
+
+```html
+<link rel="stylesheet" href="/ez-az-shell.css">
+```
+
+This file is served as a static asset by Propshaft, so no build step is required. It covers
+both TV game HTML files (`public/games/`) and phone join ERB views (`app/views/*/join.html.erb`).
+
+### 2. All shared classes use the `.ezaz-` prefix
+
+This avoids collisions with game-specific styles. Game-level CSS stays in the game file and
+uses short names without prefix. The shell CSS never sets canvas, gameplay, or controller
+layout styles.
+
+### 3. Design tokens as CSS custom properties on `:root`
+
+Brand colours (`--ez-teal`, `--ez-yellow`, `--ez-pink`, `--ez-red`, `--ez-gold`), surface
+colours (`--ez-bg`, `--ez-surface`, `--ez-border`), and the 4-slot character palette
+(`--ez-slot-0` through `--ez-slot-3`) are declared as CSS custom properties so games can
+reference them in their own bespoke styles.
+
+### 4. Store banner is always the brand gradient
+
+`.ezaz-store-banner a` uses `linear-gradient(90deg, #ff6ec7, #00ffc8, #ffe44d)` regardless of
+which game is displaying. This is a brand-level chrome, not a game-level accent.
+
+### 5. QR join box is always teal-bordered
+
+The scan-to-join action is a brand-level interaction (you are joining the EZ-AZ store, not just
+the game). `.ezaz-qr-box` always uses `rgba(0,255,200,0.3)` border and
+`rgba(0,255,200,0.06)` background.
+
+### 6. Primary button supports per-game colour overrides via CSS custom properties
+
+`.ezaz-btn-primary` reads `--ez-btn-bg` and `--ez-btn-fg` at the element level. Game join
+pages set these on the element itself:
+
+```html
+<button class="ezaz-btn-primary" style="--ez-btn-bg:#ffd23b;--ez-btn-fg:#14110c;">KICK OFF</button>
+```
+
+This means one class definition handles all game accent colours without duplication.
+
+### 7. TV slot cards use `.filled` class + `--slot-colour` CSS custom property
+
+When a phone joins, JS adds `.filled` to the `.ezaz-slot-card` and sets
+`--slot-colour` to the character's colour. The shared CSS handles the visual transition. Games
+with their own character colour palettes (e.g. Dino Jump's Slate/Pixel/Fern/Echo) still use
+the shared card structure while supplying their own colours through `--slot-colour`.
+
+### 8. Leaderboard rows and score cards rendered via JS must use `ezaz-*` class names
+
+TV games that build their leaderboard or score grids with `innerHTML` strings must use the
+shared class names (`ezaz-lb-row`, `ezaz-score-card`, etc.) in those strings. Bespoke
+equivalents (`lb-row`, `score-card`, etc.) in game-local CSS are removed once the game is
+migrated.
+
+### 9. Dino Jump EXIT button violation fixed alongside the design pass
+
+Dino Jump's phone join page was missing the EXIT button required by Phone Contract clause 4.
+Since the design pass touched that file anyway, the violation was fixed in the same commit. Dino
+Jump uses a custom cable implementation (`AzCable`) rather than `ArcadeCable`, so `attachExit`
+could not be reused; the exit handler was wired manually with the same 150 ms delay pattern.
+
+### 10. Reference games are not migrated in this pass
+
+Family Trivia, Spotlight, and Treasure Hunt served as the source of truth for the design
+tokens. Their existing styles closely match the shared system. Migrating them to use `ez-az-shell.css`
+would be purely cosmetic and requires careful regression testing of their join flows and TV views.
+That work is deferred to a future pass.
+
+---
+
+## Consequences
+
+- Three games (Snake Pit Royale, Golden Goal, Dino Jump) now share one source of truth for
+  store banner, exit button, join/lobby/gameover chrome, and TV lobby primitives.
+- New games must include `ez-az-shell.css` and follow the component conventions in
+  `docs/design-system.md`.
+- Any change to a shared primitive (e.g. updating the leaderboard row hover colour) is made
+  once in `ez-az-shell.css` and takes effect across all migrated games immediately.
+- Games using `ArcadeCable` (`ArcadeCable.attachExit`, `ArcadeCable.hostStart`) satisfy
+  Phone Contract clauses 3 and 4 automatically. Games using a custom cable must wire these
+  manually; `docs/design-system.md` documents the pattern.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,283 @@
+# EZ-AZ Design System
+
+The shared design system for EZ-AZ lives in `public/ez-az-shell.css`. It defines the design tokens and reusable shell components that wrap every game. All shared classes use the `.ezaz-` prefix to avoid collisions with game-specific styles.
+
+Game-specific layout, canvas, and gameplay UI belongs in each game file. This system only touches the surfaces around the game.
+
+---
+
+## Design Tokens
+
+Defined as CSS custom properties on `:root`:
+
+| Token | Value | Use |
+|---|---|---|
+| `--ez-teal` | `#00ffc8` | Primary brand accent; QR boxes; teal-themed buttons |
+| `--ez-yellow` | `#ffe44d` | Secondary brand accent; Dino Jump; start buttons |
+| `--ez-pink` | `#ff6ec7` | Tertiary brand accent; gradient use |
+| `--ez-red` | `#ff4757` | Destructive actions; exit button hover |
+| `--ez-gold` | `#ffd23b` | Leaderboard titles; Golden Goal; winner cards |
+| `--ez-bg` | `#0a0a12` | Page background |
+| `--ez-surface` | `#13131f` | Card/input backgrounds |
+| `--ez-border` | `rgba(255,255,255,0.08)` | Subtle borders |
+| `--ez-font` | `'Courier New', monospace` | Body font |
+
+### 4-Slot Character Palette
+
+The standard slot colours are consistent across all party games:
+
+| Slot | Token | Colour | Name |
+|---|---|---|---|
+| 0 | `--ez-slot-0` | `#00ffaa` | GREEN |
+| 1 | `--ez-slot-1` | `#ff3b6b` | PINK |
+| 2 | `--ez-slot-2` | `#3aa0ff` | BLUE |
+| 3 | `--ez-slot-3` | `#ffd23b` | GOLD |
+
+Games with their own character colour palette (e.g. Dino Jump uses Slate/Pixel/Fern/Echo) may override slot colours in JS while still using the shared `.ezaz-slot-card` structure.
+
+---
+
+## Shell Components
+
+### Store Banner
+
+The fixed top strip on every page. The EZ-AZ link always uses the same brand gradient regardless of the game's accent colour.
+
+```html
+<div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
+```
+
+### Exit Button (Phone Contract clause 4)
+
+Required on every phone screen. Frees the player slot server-side and returns them to the store.
+
+```html
+<button class="ezaz-exit-btn" id="exitBtn">EXIT</button>
+```
+
+Wire it using `ArcadeCable.attachExit` (shared games) or manually for games using a custom cable:
+
+```javascript
+// ArcadeCable games
+ArcadeCable.attachExit(document.getElementById('exitBtn'), sub);
+
+// Custom cable games (e.g. Dino Jump)
+document.getElementById('exitBtn').addEventListener('click', function() {
+  if (sub && mySlot !== null) { try { sub.send('leave', {}); } catch (_) {} }
+  setTimeout(function() { window.location.href = '/'; }, 150);
+});
+```
+
+### Primary Action Button
+
+The main CTA on phone join screens. Games may override the background and foreground colours with CSS custom properties.
+
+```html
+<!-- Default teal -->
+<button class="ezaz-btn-primary" id="joinBtn">JOIN GAME</button>
+
+<!-- Game accent colour override -->
+<button class="ezaz-btn-primary" style="--ez-btn-bg:#ffd23b;--ez-btn-fg:#141004;">KICK OFF</button>
+```
+
+### Outline Button
+
+Secondary actions on lobby and game-over screens (back to lobby, back to store). Replaces the near-invisible `rgba(255,255,255,0.2)` treatment used by early games.
+
+```html
+<button class="ezaz-btn-outline">BACK TO LOBBY</button>
+<a href="/" class="ezaz-btn-outline">BACK TO STORE</a>
+```
+
+### Name Input and Label
+
+```html
+<span class="ezaz-label">Your name</span>
+<input class="ezaz-name-input" type="text" maxlength="12" placeholder="ENTER NAME"
+       autocomplete="off" autocorrect="off" autocapitalize="characters" spellcheck="false">
+<div class="ezaz-error-msg" id="errorMsg"></div>
+```
+
+Games may override the focus border colour:
+
+```css
+/* Game-specific accent on focus */
+.ezaz-name-input:focus { border-color: #ffd23b; }
+```
+
+---
+
+## Phone Screen Layouts
+
+### Join Screen
+
+```html
+<div class="screen active" id="screenJoin">
+  <div class="join-inner">
+    <div class="game-title">GAME NAME</div>
+    <div class="game-sub">Subtitle text</div>
+    <span class="ezaz-label">Your name</span>
+    <input class="ezaz-name-input" id="nameInput" ...>
+    <div class="ezaz-error-msg" id="errorMsg"></div>
+    <button class="ezaz-btn-primary" id="joinBtn" ...>JOIN GAME</button>
+  </div>
+</div>
+```
+
+### Lobby Screen
+
+```html
+<div class="screen" id="screenLobby">
+  <div class="ezaz-lobby-inner">
+    <div class="game-title">GAME NAME</div>
+    <div class="ezaz-char-badge" id="lobbyBadge"></div>
+    <div class="ezaz-char-name" id="lobbyCharName"></div>
+    <div class="ezaz-waiting">Waiting for the host to start...</div>
+  </div>
+</div>
+```
+
+### Game Over Screen
+
+```html
+<div class="screen" id="screenOver">
+  <div class="ezaz-gameover-inner">
+    <div class="game-title">GAME NAME</div>
+    <div class="ezaz-go-rank" id="goRank"></div>
+    <div class="ezaz-go-name" id="goName"></div>
+    <div class="ezaz-go-score" id="goScore"></div>
+    <button class="ezaz-btn-outline" id="lobbyAgainBtn">BACK TO LOBBY</button>
+    <a href="/" class="ezaz-btn-outline">BACK TO STORE</a>
+  </div>
+</div>
+```
+
+---
+
+## TV Title Screen Primitives
+
+### QR Join Box
+
+The scan-to-join panel on TV title screens. Always teal-bordered because the scan action is a brand-level interaction, not a game-level one.
+
+```html
+<div class="ezaz-qr-box">
+  <p class="ezaz-qr-label">SCAN TO JOIN ON YOUR PHONE</p>
+  <img id="joinQr" alt="Scan to join" style="width:180px;height:180px;...">
+  <p id="joinUrl" class="ezaz-qr-url"></p>
+</div>
+```
+
+### Slot Cards
+
+4-up player grid on the title screen. JS adds `.filled` and sets `--slot-colour` when a player joins.
+
+```html
+<div class="ezaz-slot-card" id="slot0">
+  <div class="ezaz-slot-tag" style="color:#00ffaa;">GREEN</div>
+  <div class="ezaz-slot-name" id="slot0name">EMPTY</div>
+</div>
+```
+
+```javascript
+function updateSlot(slot, name) {
+  var el = document.getElementById('slot' + slot);
+  var nm = document.getElementById('slot' + slot + 'name');
+  if (el) {
+    if (name) {
+      el.classList.add('filled');
+      el.style.setProperty('--slot-colour', COLOURS[slot]);
+    } else {
+      el.classList.remove('filled');
+      el.style.removeProperty('--slot-colour');
+    }
+  }
+  if (nm) nm.textContent = name || 'EMPTY';
+}
+```
+
+### Leaderboard
+
+```html
+<div class="ezaz-lb-wrap" id="titleLb"></div>
+```
+
+JS renders the rows using shared classes:
+
+```javascript
+function renderLb(elId, hlName) {
+  var el = document.getElementById(elId);
+  if (!el) return;
+  if (!lbData.length) {
+    el.innerHTML = '<div class="ezaz-lb-title">HIGH SCORES</div>'
+                 + '<div class="ezaz-lb-empty">No scores yet. Be the first!</div>';
+    return;
+  }
+  var h = '<div class="ezaz-lb-title">HIGH SCORES</div>';
+  lbData.slice(0, 10).forEach(function(row, i) {
+    var hl = hlName && row.name === hlName ? ' highlight' : '';
+    h += '<div class="ezaz-lb-row' + hl + '"><span>#' + (i + 1) + ' '
+       + row.name + '</span><span>' + row.value + '</span></div>';
+  });
+  el.innerHTML = h;
+}
+```
+
+### Name Entry (leaderboard save)
+
+```html
+<div id="nameEntry" style="display:none;">
+  <p style="...">YOUR NAME:</p>
+  <input type="text" id="nameInput" class="ezaz-lb-name-input" maxlength="10" placeholder="NAME">
+  <button class="ezaz-btn-save" onclick="saveScore()">SAVE</button>
+</div>
+```
+
+### Score Cards (end screen)
+
+```javascript
+sorted.forEach(function(p, i) {
+  grid += '<div class="ezaz-score-card' + (i === 0 ? ' winner' : '') + '">';
+  grid += '<div class="ezaz-score-tag" style="color:' + p.colour + '">' + p.name + '</div>';
+  grid += '<div class="ezaz-score-val">' + p.score + ' pts</div>';
+  grid += '<div class="ezaz-score-rank">' + (i === 0 ? 'CHAMPION' : '#' + (i + 1)) + '</div>';
+  grid += '</div>';
+});
+```
+
+### Hint Text
+
+```html
+<p class="ezaz-hint">Keyboard still works &nbsp;|&nbsp; ESC to pause</p>
+```
+
+---
+
+## Applying the System to a New Game
+
+1. Add the shared stylesheet link after any Google Fonts link:
+   ```html
+   <link rel="stylesheet" href="/ez-az-shell.css">
+   ```
+
+2. Use `.ezaz-store-banner` on both the TV game and the phone join page.
+
+3. Wire the exit button on every phone screen using `.ezaz-exit-btn` and `ArcadeCable.attachExit`.
+
+4. Use `.ezaz-btn-primary` for the JOIN button, overriding `--ez-btn-bg` and `--ez-btn-fg` to match the game's accent colour.
+
+5. Use `.ezaz-btn-outline` for all secondary navigation buttons (back to lobby, back to store).
+
+6. Use the TV primitives (QR box, slot cards, leaderboard, score cards) with the standard class names so the shared CSS renders them consistently.
+
+---
+
+## Covered Games
+
+| Game | TV file | Phone join |
+|---|---|---|
+| Snake Pit Royale | `public/games/snake-pit-royale.html` | `app/views/snake_pit/join.html.erb` |
+| Golden Goal | `public/games/golden-goal.html` | `app/views/golden_goal/join.html.erb` |
+| Dino Jump | `public/games/dino-jump.html` | `app/views/dino_jump/join.html.erb` |
+
+Games predating the system (Family Trivia, Spotlight, Treasure Hunt) served as the design reference. Their existing primitives were extracted into this shared file.

--- a/public/ez-az-shell.css
+++ b/public/ez-az-shell.css
@@ -1,0 +1,424 @@
+/*
+ * ez-az-shell.css — EZ-AZ shared design system
+ *
+ * This file owns the design tokens and reusable shell components that wrap
+ * every EZ-AZ game: store banner, exit button, phone join/lobby/gameover
+ * surfaces, and the TV title-screen primitives (QR box, slot cards,
+ * leaderboard, score cards).
+ *
+ * Game-specific layout, canvas, and gameplay UI lives in each game file.
+ * This file touches only the surfaces AROUND the game.
+ *
+ * Usage (phone join pages and TV game HTML files):
+ *   <link rel="stylesheet" href="/ez-az-shell.css">
+ *
+ * All shared classes use the .ezaz- prefix to avoid collisions with
+ * game-specific styles.
+ */
+
+/* ── Design Tokens ─────────────────────────────────────────────────────── */
+:root {
+  /* Brand colours */
+  --ez-teal:    #00ffc8;
+  --ez-yellow:  #ffe44d;
+  --ez-pink:    #ff6ec7;
+  --ez-red:     #ff4757;
+  --ez-gold:    #ffd23b;
+
+  /* Surface colours */
+  --ez-bg:      #0a0a12;
+  --ez-surface: #13131f;
+  --ez-border:  rgba(255,255,255,0.08);
+
+  /* Typography */
+  --ez-font:    'Courier New', monospace;
+
+  /* 4-slot character palette (consistent across all games) */
+  --ez-slot-0:  #00ffaa;   /* GREEN */
+  --ez-slot-1:  #ff3b6b;   /* PINK  */
+  --ez-slot-2:  #3aa0ff;   /* BLUE  */
+  --ez-slot-3:  #ffd23b;   /* GOLD  */
+}
+
+
+/* ── Store Banner ──────────────────────────────────────────────────────── */
+/*
+ * Fixed top strip on every page. The EZ-AZ link is always the same brand
+ * gradient regardless of the game's own colour scheme.
+ */
+.ezaz-store-banner {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+  background: rgba(10,10,18,0.92);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  padding: 10px 16px;
+  text-align: center;
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  font-family: var(--ez-font);
+}
+.ezaz-store-banner a {
+  background: linear-gradient(90deg, #ff6ec7, #00ffc8, #ffe44d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-decoration: none;
+  font-weight: 700;
+  opacity: 0.75;
+  transition: opacity 0.2s;
+}
+.ezaz-store-banner a:hover { opacity: 1; }
+
+
+/* ── Exit Button ───────────────────────────────────────────────────────── */
+/*
+ * Fixed top-right. Frees the player's slot and sends them back to the store.
+ * Required on every phone screen by Phone Contract clause 4.
+ */
+.ezaz-exit-btn {
+  position: fixed; top: 6px; right: 10px; z-index: 101;
+  background: transparent;
+  border: 1px solid rgba(255,71,87,0.4);
+  border-radius: 6px;
+  color: rgba(255,71,87,0.7);
+  font-family: var(--ez-font);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.ezaz-exit-btn:hover { color: var(--ez-red); border-color: rgba(255,71,87,0.7); }
+
+
+/* ── Primary Action Button ─────────────────────────────────────────────── */
+/*
+ * The main CTA on phone join screens (JOIN GAME, START THE PIT, KICK OFF).
+ * Games may override --ez-btn-bg to use their own accent colour.
+ */
+.ezaz-btn-primary {
+  width: 100%; max-width: 280px;
+  padding: 16px;
+  border: none;
+  border-radius: 10px;
+  font-family: var(--ez-font);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  background: var(--ez-btn-bg, var(--ez-teal));
+  color: var(--ez-btn-fg, var(--ez-bg));
+  transition: opacity 0.15s, transform 0.1s;
+}
+.ezaz-btn-primary:hover:not(:disabled) { transform: scale(1.03); }
+.ezaz-btn-primary:disabled { opacity: 0.35; cursor: not-allowed; }
+
+
+/* ── Outline Button ────────────────────────────────────────────────────── */
+/*
+ * Secondary actions on game-over and lobby screens (BACK TO LOBBY, BACK TO
+ * STORE). Replaces the old near-invisible rgba(255,255,255,0.2) treatment.
+ */
+.ezaz-btn-outline {
+  padding: 14px 32px;
+  border: 2px solid rgba(0,255,200,0.35);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ez-teal);
+  font-family: var(--ez-font);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: border-color 0.15s, background 0.15s;
+}
+.ezaz-btn-outline:hover {
+  border-color: var(--ez-teal);
+  background: rgba(0,255,200,0.08);
+}
+
+
+/* ── Label ─────────────────────────────────────────────────────────────── */
+.ezaz-label {
+  font-size: 11px;
+  color: #678;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-family: var(--ez-font);
+}
+
+
+/* ── Name Input ────────────────────────────────────────────────────────── */
+.ezaz-name-input {
+  width: 100%;
+  background: var(--ez-surface);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  padding: 14px 16px;
+  font-family: var(--ez-font);
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  outline: none;
+}
+.ezaz-name-input:focus { border-color: var(--ez-teal); }
+.ezaz-name-input::placeholder { color: #334; }
+
+
+/* ── Error Message ─────────────────────────────────────────────────────── */
+.ezaz-error-msg {
+  color: var(--ez-red);
+  font-size: 12px;
+  text-align: center;
+  min-height: 16px;
+  font-family: var(--ez-font);
+}
+
+
+/* ── Character Badge (phone lobby avatar circle) ───────────────────────── */
+.ezaz-char-badge {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 52px;
+  border: 4px solid rgba(255,255,255,0.2);
+  background: var(--ez-surface);
+}
+
+
+/* ── Char Name ─────────────────────────────────────────────────────────── */
+.ezaz-char-name {
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  font-family: var(--ez-font);
+}
+
+
+/* ── Waiting / Status Text ─────────────────────────────────────────────── */
+.ezaz-waiting {
+  font-size: 13px;
+  color: #667;
+  letter-spacing: 0.06em;
+  text-align: center;
+  line-height: 1.6;
+  font-family: var(--ez-font);
+}
+
+
+/* ── Phone Lobby Wrapper ───────────────────────────────────────────────── */
+.ezaz-lobby-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 20px;
+  padding: 20px;
+}
+
+
+/* ── Phone Game Over Wrapper ───────────────────────────────────────────── */
+.ezaz-gameover-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 16px;
+  padding: 24px 20px;
+  text-align: center;
+}
+
+.ezaz-go-rank {
+  font-size: 56px;
+  font-weight: 900;
+  font-family: var(--ez-font);
+  line-height: 1;
+}
+
+.ezaz-go-name {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  font-family: var(--ez-font);
+}
+
+.ezaz-go-score {
+  font-size: 16px;
+  color: var(--ez-teal);
+  letter-spacing: 0.06em;
+  font-family: var(--ez-font);
+}
+
+
+/* ── TV: QR Join Box ───────────────────────────────────────────────────── */
+/*
+ * The scan-to-join panel on TV title screens. Always teal-bordered —
+ * the scan action is a brand-level interaction, not a game-level one.
+ */
+.ezaz-qr-box {
+  background: rgba(0,255,200,0.06);
+  border: 1px solid rgba(0,255,200,0.3);
+  border-radius: 10px;
+  padding: 10px 18px;
+  margin-bottom: 14px;
+  max-width: 640px;
+  width: 100%;
+}
+.ezaz-qr-label {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 8px;
+  color: #889;
+  margin-bottom: 5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.ezaz-qr-url {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 11px;
+  color: var(--ez-teal);
+  word-break: break-all;
+}
+.ezaz-qr-code {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 20px;
+  color: var(--ez-gold);
+  letter-spacing: 3px;
+  margin-top: 6px;
+}
+
+
+/* ── TV: Slot Card ─────────────────────────────────────────────────────── */
+/*
+ * Player slot in the 4-up grid on the title screen.
+ * JS adds .filled and sets --slot-colour when a player joins.
+ */
+.ezaz-slot-card {
+  border: 2px solid #242424;
+  border-radius: 10px;
+  padding: 12px 8px;
+  transition: border-color 0.3s, background 0.3s;
+}
+.ezaz-slot-card.filled {
+  border-color: var(--slot-colour, rgba(255,255,255,0.3));
+  background: color-mix(in srgb, var(--slot-colour, rgba(255,255,255,0.05)) 7%, transparent);
+}
+.ezaz-slot-tag {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 9px;
+  margin-bottom: 6px;
+}
+.ezaz-slot-name {
+  font-size: 11px;
+  color: #444;
+  line-height: 1.6;
+  font-family: 'Press Start 2P', var(--ez-font);
+  transition: color 0.3s;
+}
+.ezaz-slot-card.filled .ezaz-slot-name { color: #fff; }
+
+
+/* ── TV: Score Card (end screen) ───────────────────────────────────────── */
+.ezaz-score-card {
+  border: 2px solid #242424;
+  border-radius: 10px;
+  padding: 12px 10px;
+  transition: border-color 0.3s, background 0.3s;
+}
+.ezaz-score-card.winner {
+  border-color: var(--ez-gold);
+  background: rgba(255,210,59,0.07);
+}
+.ezaz-score-tag {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 10px;
+  margin-bottom: 5px;
+}
+.ezaz-score-val {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 13px;
+  color: var(--ez-teal);
+  margin-bottom: 3px;
+}
+.ezaz-score-rank {
+  font-size: 10px;
+  color: var(--ez-gold);
+  font-family: 'Press Start 2P', var(--ez-font);
+}
+
+
+/* ── TV: Leaderboard ───────────────────────────────────────────────────── */
+.ezaz-lb-wrap { margin: 10px auto; max-width: 340px; width: 100%; text-align: left; }
+.ezaz-lb-title {
+  font-family: 'Press Start 2P', var(--ez-font);
+  font-size: 9px;
+  color: var(--ez-gold);
+  margin-bottom: 8px;
+  text-align: center;
+}
+.ezaz-lb-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 3px 8px;
+  font-size: 10px;
+  color: #9ab;
+  font-family: 'Press Start 2P', var(--ez-font);
+}
+.ezaz-lb-row.highlight {
+  color: var(--ez-teal);
+  background: rgba(0,255,200,0.08);
+  border-radius: 4px;
+}
+.ezaz-lb-empty {
+  color: #456;
+  font-size: 11px;
+  text-align: center;
+  padding: 8px;
+  font-family: 'Press Start 2P', var(--ez-font);
+}
+.ezaz-lb-name-input {
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #fff;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  width: 130px;
+  font-family: 'Press Start 2P', var(--ez-font);
+  text-transform: uppercase;
+  outline: none;
+}
+.ezaz-lb-name-input:focus { border-color: var(--ez-teal); }
+.ezaz-btn-save {
+  padding: 6px 14px;
+  font-size: 10px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: rgba(0,255,200,0.15);
+  color: var(--ez-teal);
+  font-weight: 700;
+  font-family: 'Press Start 2P', var(--ez-font);
+  transition: background 0.15s;
+}
+.ezaz-btn-save:hover { background: rgba(0,255,200,0.28); }
+
+
+/* ── TV: Hint Text ─────────────────────────────────────────────────────── */
+.ezaz-hint {
+  color: #456;
+  font-size: 9px;
+  margin-bottom: 10px;
+  font-family: 'Press Start 2P', var(--ez-font);
+  line-height: 1.7;
+}

--- a/public/games/dino-jump.html
+++ b/public/games/dino-jump.html
@@ -10,6 +10,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/ez-az-shell.css">
 <title>Dino Jump - EZ-AZ</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -17,36 +18,17 @@
   #wrap { position: relative; }
   canvas { display: block; }
   .overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; color: white; text-align: center; z-index: 10; padding: 20px; overflow-y: auto; background: rgba(0,0,0,0.90); }
-  .store-banner { position: fixed; top: 0; left: 0; width: 100%; text-align: center; padding: 6px 0; z-index: 30; background: rgba(0,0,0,0.6); }
-  .store-banner a { text-decoration: none; font-family: 'Press Start 2P', monospace; font-size: 12px; background: linear-gradient(to right, #ff6ec7, #00ffc8, #ffe44d); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; opacity: 0.6; transition: opacity 0.2s; }
-  .store-banner a:hover { opacity: 1; }
-  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #555, #333); color: white; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
+  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: var(--ez-yellow); color: #111; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn:hover { transform: scale(1.06); }
   .btn-quit { margin-top: 8px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #cc4444, #aa2222); color: white; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn-quit:hover { transform: scale(1.06); }
   .controls-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 14px 0; max-width: 680px; width: 100%; }
-  .ctrl-card { border: 2px solid #333; border-radius: 10px; padding: 12px 8px; }
-  .ctrl-name { font-family: 'Press Start 2P', monospace; font-size: 9px; margin-bottom: 6px; }
-  .ctrl-keys { font-size: 11px; color: #888; line-height: 1.6; }
-  .lb-wrap { margin: 10px auto; max-width: 320px; width: 100%; text-align: left; }
-  .lb-title { font-family: 'Press Start 2P', monospace; font-size: 9px; color: #ffe44d; margin-bottom: 8px; text-align: center; }
-  .lb-row { display: flex; justify-content: space-between; padding: 3px 8px; font-size: 10px; color: #aaa; font-family: 'Press Start 2P', monospace; }
-  .lb-row.highlight { color: #00ffc8; background: rgba(0,255,200,0.08); border-radius: 4px; }
-  .lb-empty { color: #555; font-size: 11px; text-align: center; padding: 8px; }
   .score-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin: 10px 0; max-width: 480px; width: 100%; }
-  .score-card { border: 2px solid #333; border-radius: 10px; padding: 12px 10px; }
-  .score-card.winner { border-color: #ffe44d; background: rgba(255,228,77,0.06); }
-  .score-char { font-family: 'Press Start 2P', monospace; font-size: 10px; margin-bottom: 5px; }
-  .score-val { font-family: 'Press Start 2P', monospace; font-size: 13px; color: #00ffc8; margin-bottom: 3px; }
-  .score-rank { font-size: 10px; color: #ffe44d; font-family: 'Press Start 2P', monospace; }
   #nameEntry { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 10px 0; }
-  .lb-name-input { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.3); color: #fff; padding: 6px 10px; font-size: 12px; border-radius: 6px; width: 120px; font-family: 'Press Start 2P', monospace; text-transform: uppercase; }
-  .btn-small { padding: 6px 14px; font-size: 10px; border: none; border-radius: 6px; cursor: pointer; background: rgba(255,228,77,0.15); color: #ffe44d; font-weight: bold; font-family: 'Press Start 2P', monospace; }
-  .btn-small:hover { background: rgba(255,228,77,0.28); }
 </style>
 </head>
 <body>
-<div class="store-banner"><a href="/">EZ-AZ</a></div>
+<div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
 <div id="wrap">
 
 <div id="titleScreen" class="overlay">
@@ -54,35 +36,35 @@
   <p style="color:#555; font-size:10px; margin-bottom:12px; font-style:italic;">Climb higher than everyone else.</p>
 
   <!-- Join URL for phones -->
-  <div style="background:rgba(255,228,77,0.07); border:1px solid rgba(255,228,77,0.2); border-radius:10px; padding:10px 18px; margin-bottom:12px; max-width:600px; width:100%;">
-    <p style="font-family:'Press Start 2P',monospace; font-size:8px; color:#888; margin-bottom:4px;">SCAN TO JOIN ON YOUR PHONE</p>
+  <div class="ezaz-qr-box">
+    <p class="ezaz-qr-label">SCAN TO JOIN ON YOUR PHONE</p>
     <img id="joinQr" alt="Scan to join" style="width:180px;height:180px;background:#fff;border-radius:10px;padding:8px;margin:4px auto 8px;display:none;" />
-    <p id="joinUrl" style="font-family:'Press Start 2P',monospace; font-size:10px; color:#ffe44d; word-break:break-all;"></p>
+    <p id="joinUrl" class="ezaz-qr-url"></p>
   </div>
 
   <!-- Player slots -->
   <div class="controls-grid" id="slotsGrid">
-    <div class="ctrl-card" id="slot0" style="border-color:#333;">
-      <div class="ctrl-name" style="color:#a0a0a0;">SLATE</div>
-      <div class="ctrl-keys" id="slot0name" style="color:#444;">EMPTY</div>
+    <div class="ezaz-slot-card" id="slot0">
+      <div class="ezaz-slot-tag" style="color:#a0a0a0;">SLATE</div>
+      <div class="ezaz-slot-name" id="slot0name">EMPTY</div>
     </div>
-    <div class="ctrl-card" id="slot1" style="border-color:#333;">
-      <div class="ctrl-name" style="color:#00ffcc;">PIXEL</div>
-      <div class="ctrl-keys" id="slot1name" style="color:#444;">EMPTY</div>
+    <div class="ezaz-slot-card" id="slot1">
+      <div class="ezaz-slot-tag" style="color:#00ffcc;">PIXEL</div>
+      <div class="ezaz-slot-name" id="slot1name">EMPTY</div>
     </div>
-    <div class="ctrl-card" id="slot2" style="border-color:#333;">
-      <div class="ctrl-name" style="color:#44cc66;">FERN</div>
-      <div class="ctrl-keys" id="slot2name" style="color:#444;">EMPTY</div>
+    <div class="ezaz-slot-card" id="slot2">
+      <div class="ezaz-slot-tag" style="color:#44cc66;">FERN</div>
+      <div class="ezaz-slot-name" id="slot2name">EMPTY</div>
     </div>
-    <div class="ctrl-card" id="slot3" style="border-color:#333;">
-      <div class="ctrl-name" style="color:#aa88ff;">ECHO</div>
-      <div class="ctrl-keys" id="slot3name" style="color:#444;">EMPTY</div>
+    <div class="ezaz-slot-card" id="slot3">
+      <div class="ezaz-slot-tag" style="color:#aa88ff;">ECHO</div>
+      <div class="ezaz-slot-name" id="slot3name">EMPTY</div>
     </div>
   </div>
 
   <p style="color:#444; font-size:9px; margin-bottom:10px; font-family:'Press Start 2P',monospace;">Keyboard still works &nbsp;|&nbsp; ESC to pause</p>
   <button class="btn" onclick="tvStart()">START GAME</button>
-  <div class="lb-wrap" id="titleLb"></div>
+  <div class="ezaz-lb-wrap" id="titleLb"></div>
 </div>
 
 <div id="pauseScreen" class="overlay" style="display:none;">
@@ -96,10 +78,10 @@
   <div class="score-grid" id="scoreGrid"></div>
   <div id="nameEntry" style="display:none;">
     <p style="font-family:'Press Start 2P',monospace; font-size:9px; color:#aaa;">YOUR NAME:</p>
-    <input type="text" id="nameInput" class="lb-name-input" maxlength="10" placeholder="NAME">
-    <button class="btn-small" onclick="saveScore()">SAVE</button>
+    <input type="text" id="nameInput" class="ezaz-lb-name-input" maxlength="10" placeholder="NAME">
+    <button class="ezaz-btn-save" onclick="saveScore()">SAVE</button>
   </div>
-  <div class="lb-wrap" id="endLb"></div>
+  <div class="ezaz-lb-wrap" id="endLb"></div>
   <button class="btn" onclick="location.reload()">PLAY AGAIN</button>
   <button class="btn-quit" onclick="window.location.href='/'">BACK TO STORE</button>
 </div>
@@ -498,13 +480,13 @@ function renderLb(elId, hlName) {
   var el = document.getElementById(elId);
   if (!el) return;
   if (!lbData.length) {
-    el.innerHTML = '<div class="lb-title">HIGH SCORES</div><div class="lb-empty">No scores yet. Be the first!</div>';
+    el.innerHTML = '<div class="ezaz-lb-title">HIGH SCORES</div><div class="ezaz-lb-empty">No scores yet. Be the first!</div>';
     return;
   }
-  var h = '<div class="lb-title">HIGH SCORES</div>';
+  var h = '<div class="ezaz-lb-title">HIGH SCORES</div>';
   lbData.slice(0, 10).forEach(function(row, i) {
     var hl = hlName && row.name === hlName ? ' highlight' : '';
-    h += '<div class="lb-row' + hl + '"><span>#' + (i+1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
+    h += '<div class="ezaz-lb-row' + hl + '"><span>#' + (i+1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
   });
   el.innerHTML = h;
 }
@@ -590,8 +572,16 @@ function updateSlot(slot, name) {
   var cols = ['#a0a0a0','#00ffcc','#44cc66','#aa88ff'];
   var el = document.getElementById('slot' + slot);
   var nm = document.getElementById('slot' + slot + 'name');
-  if (el) el.style.borderColor = name ? cols[slot] : '#333';
-  if (nm) { nm.textContent = name || 'EMPTY'; nm.style.color = name ? '#fff' : '#444'; }
+  if (el) {
+    if (name) {
+      el.classList.add('filled');
+      el.style.setProperty('--slot-colour', cols[slot]);
+    } else {
+      el.classList.remove('filled');
+      el.style.removeProperty('--slot-colour');
+    }
+  }
+  if (nm) nm.textContent = name || 'EMPTY';
 }
 
 // ---- Game state ----
@@ -654,10 +644,10 @@ function checkGameOver() {
   var grid = '';
   sorted.forEach(function(w, i) {
     var ch = CHARS[w.ci];
-    grid += '<div class="score-card' + (i === 0 ? ' winner' : '') + '">';
-    grid += '<div class="score-char" style="color:' + ch.colour + '">' + ch.name + '</div>';
-    grid += '<div class="score-val">' + w.finalScore + ' ALT</div>';
-    grid += '<div class="score-rank">' + (i === 0 ? 'WINNER!' : '#' + (i+1)) + '</div>';
+    grid += '<div class="ezaz-score-card' + (i === 0 ? ' winner' : '') + '">';
+    grid += '<div class="ezaz-score-tag" style="color:' + ch.colour + '">' + ch.name + '</div>';
+    grid += '<div class="ezaz-score-val">' + w.finalScore + ' ALT</div>';
+    grid += '<div class="ezaz-score-rank">' + (i === 0 ? 'WINNER!' : '#' + (i+1)) + '</div>';
     grid += '</div>';
   });
   document.getElementById('scoreGrid').innerHTML = grid;

--- a/public/games/golden-goal.html
+++ b/public/games/golden-goal.html
@@ -12,6 +12,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/ez-az-shell.css">
 <title>Golden Goal - EZ-AZ</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -19,64 +20,42 @@
   #wrap { position: relative; }
   canvas { display: block; }
   .overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; color: white; text-align: center; z-index: 10; padding: 20px; overflow-y: auto; background: rgba(4,7,10,0.92); }
-  .store-banner { position: fixed; top: 0; left: 0; width: 100%; text-align: center; padding: 6px 0; z-index: 30; background: rgba(0,0,0,0.6); }
-  .store-banner a { text-decoration: none; font-family: 'Press Start 2P', monospace; font-size: 12px; background: linear-gradient(to right, #00ffaa, #3aa0ff, #ffd23b); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; opacity: 0.6; transition: opacity 0.2s; }
-  .store-banner a:hover { opacity: 1; }
-  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #ffd23b, #cc9a00); color: #141004; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
+  /* Game-specific action buttons: gold theme matches the Golden Goal brand */
+  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: var(--ez-gold); color: #141004; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn:hover { transform: scale(1.06); }
   .btn-quit { margin-top: 8px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #cc4444, #aa2222); color: white; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn-quit:hover { transform: scale(1.06); }
-  .join-box { background:rgba(255,210,59,0.06); border:1px solid rgba(255,210,59,0.25); border-radius:10px; padding:10px 18px; margin-bottom:14px; max-width:640px; width:100%; }
-  .join-label { font-family:'Press Start 2P',monospace; font-size:8px; color:#789; margin-bottom:5px; }
-  .join-url { font-family:'Press Start 2P',monospace; font-size:11px; color:#00ffaa; word-break:break-all; }
-  .join-code { font-family:'Press Start 2P',monospace; font-size:20px; color:#ffd23b; letter-spacing:3px; margin-top:6px; }
+  /* Layout grids (game-specific) */
   .slots-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 14px 0; max-width: 700px; width: 100%; }
-  .slot-card { border: 2px solid #222; border-radius: 10px; padding: 12px 8px; transition: border-color 0.2s; }
-  .slot-tag { font-family: 'Press Start 2P', monospace; font-size: 9px; margin-bottom: 6px; }
-  .slot-name { font-size: 11px; color: #444; line-height: 1.6; font-family: 'Press Start 2P', monospace; }
-  .lb-wrap { margin: 10px auto; max-width: 340px; width: 100%; text-align: left; }
-  .lb-title { font-family: 'Press Start 2P', monospace; font-size: 9px; color: #ffd23b; margin-bottom: 8px; text-align: center; }
-  .lb-row { display: flex; justify-content: space-between; padding: 3px 8px; font-size: 10px; color: #9ab; font-family: 'Press Start 2P', monospace; }
-  .lb-row.highlight { color: #00ffaa; background: rgba(0,255,170,0.08); border-radius: 4px; }
-  .lb-empty { color: #456; font-size: 11px; text-align: center; padding: 8px; }
   .score-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin: 10px 0; max-width: 520px; width: 100%; }
-  .score-card { border: 2px solid #222; border-radius: 10px; padding: 12px 10px; }
-  .score-card.winner { border-color: #ffd23b; background: rgba(255,210,59,0.07); }
-  .score-tag { font-family: 'Press Start 2P', monospace; font-size: 10px; margin-bottom: 5px; }
-  .score-val { font-family: 'Press Start 2P', monospace; font-size: 13px; color: #00ffaa; margin-bottom: 3px; }
-  .score-rank { font-size: 10px; color: #ffd23b; font-family: 'Press Start 2P', monospace; }
   #nameEntry { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 10px 0; }
-  .lb-name-input { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.3); color: #fff; padding: 6px 10px; font-size: 12px; border-radius: 6px; width: 130px; font-family: 'Press Start 2P', monospace; text-transform: uppercase; }
-  .btn-small { padding: 6px 14px; font-size: 10px; border: none; border-radius: 6px; cursor: pointer; background: rgba(255,210,59,0.15); color: #ffd23b; font-weight: bold; font-family: 'Press Start 2P', monospace; }
-  .btn-small:hover { background: rgba(255,210,59,0.28); }
-  .hint { color: #456; font-size: 9px; margin-bottom: 10px; font-family: 'Press Start 2P', monospace; line-height: 1.7; }
 </style>
 </head>
 <body>
-<div class="store-banner"><a href="/">EZ-AZ</a></div>
+<div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
 <div id="wrap">
 
 <div id="titleScreen" class="overlay">
   <h1 style="font-family:'Press Start 2P',monospace; font-size:30px; color:#ffd23b; margin-bottom:4px; text-shadow:0 0 18px rgba(255,210,59,0.6);">GOLDEN GOAL</h1>
   <p style="color:#567; font-size:10px; margin-bottom:14px; font-style:italic;">Step up to the spot. Pick your corner. Glory or heartbreak on one kick.</p>
 
-  <div class="join-box">
-    <p class="join-label">GRAB YOUR PHONE — SCAN TO JOIN</p>
+  <div class="ezaz-qr-box">
+    <p class="ezaz-qr-label">GRAB YOUR PHONE &mdash; SCAN TO JOIN</p>
     <img id="joinQr" alt="Scan to join" style="width:180px;height:180px;background:#fff;border-radius:10px;padding:8px;margin:4px auto 8px;display:none;" />
-    <p id="joinUrl" class="join-url"></p>
-    <p class="join-code">CODE <span id="joinCode"></span></p>
+    <p id="joinUrl" class="ezaz-qr-url"></p>
+    <p class="ezaz-qr-code">CODE <span id="joinCode"></span></p>
   </div>
 
   <div class="slots-grid" id="slotsGrid">
-    <div class="slot-card" id="slot0"><div class="slot-tag" style="color:#00ffaa;">GREEN</div><div class="slot-name" id="slot0name">EMPTY</div></div>
-    <div class="slot-card" id="slot1"><div class="slot-tag" style="color:#ff3b6b;">PINK</div><div class="slot-name" id="slot1name">EMPTY</div></div>
-    <div class="slot-card" id="slot2"><div class="slot-tag" style="color:#3aa0ff;">BLUE</div><div class="slot-name" id="slot2name">EMPTY</div></div>
-    <div class="slot-card" id="slot3"><div class="slot-tag" style="color:#ffd23b;">GOLD</div><div class="slot-name" id="slot3name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot0"><div class="ezaz-slot-tag" style="color:#00ffaa;">GREEN</div><div class="ezaz-slot-name" id="slot0name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot1"><div class="ezaz-slot-tag" style="color:#ff3b6b;">PINK</div><div class="ezaz-slot-name" id="slot1name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot2"><div class="ezaz-slot-tag" style="color:#3aa0ff;">BLUE</div><div class="ezaz-slot-name" id="slot2name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot3"><div class="ezaz-slot-tag" style="color:#ffd23b;">GOLD</div><div class="ezaz-slot-name" id="slot3name">EMPTY</div></div>
   </div>
 
-  <p class="hint">Phones are the controllers — picks stay secret &nbsp;|&nbsp; First phone in is the host and can start &nbsp;|&nbsp; Empty slots get an Az bot &nbsp;|&nbsp; 5 shots each &middot; ESC pauses</p>
+  <p class="ezaz-hint">Phones are the controllers &mdash; picks stay secret &nbsp;|&nbsp; First phone in is the host and can start &nbsp;|&nbsp; Empty slots get an Az bot &nbsp;|&nbsp; 5 shots each &middot; ESC pauses</p>
   <button class="btn" id="btnStart" onclick="tvStart()">KICK OFF</button>
-  <div class="lb-wrap" id="titleLb"></div>
+  <div class="ezaz-lb-wrap" id="titleLb"></div>
 </div>
 
 <div id="pauseScreen" class="overlay" style="display:none;">
@@ -90,10 +69,10 @@
   <div class="score-grid" id="scoreGrid"></div>
   <div id="nameEntry" style="display:none;">
     <p style="font-family:'Press Start 2P',monospace; font-size:9px; color:#9ab;">CHAMPION NAME:</p>
-    <input type="text" id="nameInput" class="lb-name-input" maxlength="10" placeholder="NAME">
-    <button class="btn-small" id="btnSave" onclick="saveScore()">SAVE</button>
+    <input type="text" id="nameInput" class="ezaz-lb-name-input" maxlength="10" placeholder="NAME">
+    <button class="ezaz-btn-save" id="btnSave" onclick="saveScore()">SAVE</button>
   </div>
-  <div class="lb-wrap" id="endLb"></div>
+  <div class="ezaz-lb-wrap" id="endLb"></div>
   <button class="btn" id="btnPlayAgain" onclick="playAgain()">PLAY AGAIN</button>
   <button class="btn-quit" id="btnStore" onclick="goStore()">BACK TO STORE</button>
 </div>
@@ -237,11 +216,11 @@ async function fetchLb() {
 function renderLb(elId, hlName) {
   var el = document.getElementById(elId);
   if (!el) return;
-  if (!lbData.length) { el.innerHTML = '<div class="lb-title">HIGH SCORES</div><div class="lb-empty">No scores yet. Be the first!</div>'; return; }
-  var h = '<div class="lb-title">HIGH SCORES</div>';
+  if (!lbData.length) { el.innerHTML = '<div class="ezaz-lb-title">HIGH SCORES</div><div class="ezaz-lb-empty">No scores yet. Be the first!</div>'; return; }
+  var h = '<div class="ezaz-lb-title">HIGH SCORES</div>';
   lbData.slice(0, 10).forEach(function(row, i) {
     var hl = hlName && row.name === hlName ? ' highlight' : '';
-    h += '<div class="lb-row' + hl + '"><span>#' + (i + 1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
+    h += '<div class="ezaz-lb-row' + hl + '"><span>#' + (i + 1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
   });
   el.innerHTML = h;
 }
@@ -543,10 +522,10 @@ function endMatch() {
 
   var grid = '';
   ranked.forEach(function(p, i) {
-    grid += '<div class="score-card' + (i === 0 ? ' winner' : '') + '">';
-    grid += '<div class="score-tag" style="color:' + p.col + '">' + p.name + (p.isBot ? ' (BOT)' : '') + '</div>';
-    grid += '<div class="score-val">' + p.score + ' pts</div>';
-    grid += '<div class="score-rank">' + (i === 0 ? 'CHAMPION' : '#' + (i + 1)) + ' &middot; ' + p.goals + ' goals &middot; ' + p.saves + ' saves</div>';
+    grid += '<div class="ezaz-score-card' + (i === 0 ? ' winner' : '') + '">';
+    grid += '<div class="ezaz-score-tag" style="color:' + p.col + '">' + p.name + (p.isBot ? ' (BOT)' : '') + '</div>';
+    grid += '<div class="ezaz-score-val">' + p.score + ' pts</div>';
+    grid += '<div class="ezaz-score-rank">' + (i === 0 ? 'CHAMPION' : '#' + (i + 1)) + ' &middot; ' + p.goals + ' goals &middot; ' + p.saves + ' saves</div>';
     grid += '</div>';
   });
   document.getElementById('scoreGrid').innerHTML = grid;

--- a/public/games/snake-pit-royale.html
+++ b/public/games/snake-pit-royale.html
@@ -11,6 +11,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/ez-az-shell.css">
 <title>Snake Pit Royale - EZ-AZ</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -18,64 +19,42 @@
   #wrap { position: relative; }
   canvas { display: block; }
   .overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; color: white; text-align: center; z-index: 10; padding: 20px; overflow-y: auto; background: rgba(4,7,10,0.92); }
-  .store-banner { position: fixed; top: 0; left: 0; width: 100%; text-align: center; padding: 6px 0; z-index: 30; background: rgba(0,0,0,0.6); }
-  .store-banner a { text-decoration: none; font-family: 'Press Start 2P', monospace; font-size: 12px; background: linear-gradient(to right, #00ffaa, #3aa0ff, #ffd23b); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; opacity: 0.6; transition: opacity 0.2s; }
-  .store-banner a:hover { opacity: 1; }
-  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #00cc88, #008f5e); color: #04140d; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
+  /* Game-specific action buttons */
+  .btn { margin-top: 14px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: var(--ez-teal); color: #04140d; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn:hover { transform: scale(1.06); }
   .btn-quit { margin-top: 8px; padding: 12px 36px; font-size: 14px; border: none; border-radius: 10px; cursor: pointer; background: linear-gradient(135deg, #cc4444, #aa2222); color: white; font-weight: bold; transition: transform 0.1s; font-family: 'Press Start 2P', monospace; }
   .btn-quit:hover { transform: scale(1.06); }
-  .join-box { background:rgba(0,255,170,0.06); border:1px solid rgba(0,255,170,0.25); border-radius:10px; padding:10px 18px; margin-bottom:14px; max-width:640px; width:100%; }
-  .join-label { font-family:'Press Start 2P',monospace; font-size:8px; color:#789; margin-bottom:5px; }
-  .join-url { font-family:'Press Start 2P',monospace; font-size:11px; color:#00ffaa; word-break:break-all; }
-  .join-code { font-family:'Press Start 2P',monospace; font-size:20px; color:#ffd23b; letter-spacing:3px; margin-top:6px; }
+  /* Layout grids (game-specific) */
   .slots-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 14px 0; max-width: 700px; width: 100%; }
-  .slot-card { border: 2px solid #222; border-radius: 10px; padding: 12px 8px; transition: border-color 0.2s; }
-  .slot-tag { font-family: 'Press Start 2P', monospace; font-size: 9px; margin-bottom: 6px; }
-  .slot-name { font-size: 11px; color: #444; line-height: 1.6; font-family: 'Press Start 2P', monospace; }
-  .lb-wrap { margin: 10px auto; max-width: 340px; width: 100%; text-align: left; }
-  .lb-title { font-family: 'Press Start 2P', monospace; font-size: 9px; color: #ffd23b; margin-bottom: 8px; text-align: center; }
-  .lb-row { display: flex; justify-content: space-between; padding: 3px 8px; font-size: 10px; color: #9ab; font-family: 'Press Start 2P', monospace; }
-  .lb-row.highlight { color: #00ffaa; background: rgba(0,255,170,0.08); border-radius: 4px; }
-  .lb-empty { color: #456; font-size: 11px; text-align: center; padding: 8px; }
   .score-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin: 10px 0; max-width: 520px; width: 100%; }
-  .score-card { border: 2px solid #222; border-radius: 10px; padding: 12px 10px; }
-  .score-card.winner { border-color: #ffd23b; background: rgba(255,210,59,0.07); }
-  .score-tag { font-family: 'Press Start 2P', monospace; font-size: 10px; margin-bottom: 5px; }
-  .score-val { font-family: 'Press Start 2P', monospace; font-size: 13px; color: #00ffaa; margin-bottom: 3px; }
-  .score-rank { font-size: 10px; color: #ffd23b; font-family: 'Press Start 2P', monospace; }
   #nameEntry { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 10px 0; }
-  .lb-name-input { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.3); color: #fff; padding: 6px 10px; font-size: 12px; border-radius: 6px; width: 130px; font-family: 'Press Start 2P', monospace; text-transform: uppercase; }
-  .btn-small { padding: 6px 14px; font-size: 10px; border: none; border-radius: 6px; cursor: pointer; background: rgba(255,210,59,0.15); color: #ffd23b; font-weight: bold; font-family: 'Press Start 2P', monospace; }
-  .btn-small:hover { background: rgba(255,210,59,0.28); }
-  .hint { color: #456; font-size: 9px; margin-bottom: 10px; font-family: 'Press Start 2P', monospace; line-height: 1.7; }
 </style>
 </head>
 <body>
-<div class="store-banner"><a href="/">EZ-AZ</a></div>
+<div class="ezaz-store-banner"><a href="/">EZ-AZ</a></div>
 <div id="wrap">
 
 <div id="titleScreen" class="overlay">
   <h1 style="font-family:'Press Start 2P',monospace; font-size:30px; color:#00ffaa; margin-bottom:4px; text-shadow:0 0 18px rgba(0,255,170,0.6);">SNAKE PIT ROYALE</h1>
   <p style="color:#567; font-size:10px; margin-bottom:14px; font-style:italic;">Four snakes. One shrinking pit. Last one slithering wins.</p>
 
-  <div class="join-box">
-    <p class="join-label">GRAB YOUR PHONE — SCAN TO JOIN</p>
+  <div class="ezaz-qr-box">
+    <p class="ezaz-qr-label">GRAB YOUR PHONE &mdash; SCAN TO JOIN</p>
     <img id="joinQr" alt="Scan to join" style="width:180px;height:180px;background:#fff;border-radius:10px;padding:8px;margin:4px auto 8px;display:none;" />
-    <p id="joinUrl" class="join-url"></p>
-    <p class="join-code">CODE <span id="joinCode"></span></p>
+    <p id="joinUrl" class="ezaz-qr-url"></p>
+    <p class="ezaz-qr-code">CODE <span id="joinCode"></span></p>
   </div>
 
   <div class="slots-grid" id="slotsGrid">
-    <div class="slot-card" id="slot0"><div class="slot-tag" style="color:#00ffaa;">GREEN</div><div class="slot-name" id="slot0name">EMPTY</div></div>
-    <div class="slot-card" id="slot1"><div class="slot-tag" style="color:#ff3b6b;">PINK</div><div class="slot-name" id="slot1name">EMPTY</div></div>
-    <div class="slot-card" id="slot2"><div class="slot-tag" style="color:#3aa0ff;">BLUE</div><div class="slot-name" id="slot2name">EMPTY</div></div>
-    <div class="slot-card" id="slot3"><div class="slot-tag" style="color:#ffd23b;">GOLD</div><div class="slot-name" id="slot3name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot0"><div class="ezaz-slot-tag" style="color:#00ffaa;">GREEN</div><div class="ezaz-slot-name" id="slot0name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot1"><div class="ezaz-slot-tag" style="color:#ff3b6b;">PINK</div><div class="ezaz-slot-name" id="slot1name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot2"><div class="ezaz-slot-tag" style="color:#3aa0ff;">BLUE</div><div class="ezaz-slot-name" id="slot2name">EMPTY</div></div>
+    <div class="ezaz-slot-card" id="slot3"><div class="ezaz-slot-tag" style="color:#ffd23b;">GOLD</div><div class="ezaz-slot-name" id="slot3name">EMPTY</div></div>
   </div>
 
-  <p class="hint">Empty slots get an Az bot &nbsp;|&nbsp; First phone in is the host and can start &nbsp;|&nbsp; Keyboard works too: P1 arrows &middot; P2 WASD &middot; P3 IJKL &middot; ESC pauses</p>
+  <p class="ezaz-hint">Empty slots get an Az bot &nbsp;|&nbsp; First phone in is the host and can start &nbsp;|&nbsp; Keyboard works too: P1 arrows &middot; P2 WASD &middot; P3 IJKL &middot; ESC pauses</p>
   <button class="btn" id="btnStart" onclick="tvStart()">START THE PIT</button>
-  <div class="lb-wrap" id="titleLb"></div>
+  <div class="ezaz-lb-wrap" id="titleLb"></div>
 </div>
 
 <div id="pauseScreen" class="overlay" style="display:none;">
@@ -89,10 +68,10 @@
   <div class="score-grid" id="scoreGrid"></div>
   <div id="nameEntry" style="display:none;">
     <p style="font-family:'Press Start 2P',monospace; font-size:9px; color:#9ab;">CHAMPION NAME:</p>
-    <input type="text" id="nameInput" class="lb-name-input" maxlength="10" placeholder="NAME">
-    <button class="btn-small" onclick="saveScore()">SAVE</button>
+    <input type="text" id="nameInput" class="ezaz-lb-name-input" maxlength="10" placeholder="NAME">
+    <button class="ezaz-btn-save" onclick="saveScore()">SAVE</button>
   </div>
-  <div class="lb-wrap" id="endLb"></div>
+  <div class="ezaz-lb-wrap" id="endLb"></div>
   <button class="btn" id="btnPlayAgain" onclick="playAgain()">PLAY AGAIN</button>
   <button class="btn-quit" id="btnStore" onclick="goStore()">BACK TO STORE</button>
 </div>
@@ -449,11 +428,11 @@ async function fetchLb() {
 function renderLb(elId, hlName) {
   var el = document.getElementById(elId);
   if (!el) return;
-  if (!lbData.length) { el.innerHTML = '<div class="lb-title">HIGH SCORES</div><div class="lb-empty">No scores yet. Be the first!</div>'; return; }
-  var h = '<div class="lb-title">HIGH SCORES</div>';
+  if (!lbData.length) { el.innerHTML = '<div class="ezaz-lb-title">HIGH SCORES</div><div class="ezaz-lb-empty">No scores yet. Be the first!</div>'; return; }
+  var h = '<div class="ezaz-lb-title">HIGH SCORES</div>';
   lbData.slice(0, 10).forEach(function(row, i) {
     var hl = hlName && row.name === hlName ? ' highlight' : '';
-    h += '<div class="lb-row' + hl + '"><span>#' + (i + 1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
+    h += '<div class="ezaz-lb-row' + hl + '"><span>#' + (i + 1) + ' ' + row.name + '</span><span>' + row.value + '</span></div>';
   });
   el.innerHTML = h;
 }
@@ -672,10 +651,10 @@ function endMatch() {
 
   var grid = '';
   ranked.forEach(function(s, i) {
-    grid += '<div class="score-card' + (i === 0 ? ' winner' : '') + '">';
-    grid += '<div class="score-tag" style="color:' + s.col + '">' + s.name + (s.isBot ? ' (BOT)' : '') + '</div>';
-    grid += '<div class="score-val">' + s.score + ' pts</div>';
-    grid += '<div class="score-rank">' + (i === 0 ? 'CHAMPION' : '#' + (i + 1)) + '</div>';
+    grid += '<div class="ezaz-score-card' + (i === 0 ? ' winner' : '') + '">';
+    grid += '<div class="ezaz-score-tag" style="color:' + s.col + '">' + s.name + (s.isBot ? ' (BOT)' : '') + '</div>';
+    grid += '<div class="ezaz-score-val">' + s.score + ' pts</div>';
+    grid += '<div class="ezaz-score-rank">' + (i === 0 ? 'CHAMPION' : '#' + (i + 1)) + '</div>';
     grid += '</div>';
   });
   document.getElementById('scoreGrid').innerHTML = grid;


### PR DESCRIPTION
## What this does

Extracts the visual primitives that were being copied across three games into a single shared stylesheet (`public/ez-az-shell.css`), then applies it to all six surfaces: the TV title screens and phone join pages for Dino Jump, Golden Goal, and Snake Pit Royale.

Net result: ~200 lines of duplicated bespoke CSS removed, one source of truth for every shared component, and four concrete visual fixes that were previously invisible as separate per-game bugs.

---

## Shared primitives added (`public/ez-az-shell.css`)

All classes use the `.ezaz-` prefix to avoid collisions with game-specific styles.

| Class | What it is |
|---|---|
| `.ezaz-store-banner` | Fixed top strip; EZ-AZ link always uses the brand gradient |
| `.ezaz-exit-btn` | Fixed top-right red EXIT button (Phone Contract clause 4) |
| `.ezaz-btn-primary` | JOIN / START button; per-game colour via `--ez-btn-bg` / `--ez-btn-fg` |
| `.ezaz-btn-outline` | Secondary nav buttons (BACK TO LOBBY, BACK TO STORE) |
| `.ezaz-name-input` / `.ezaz-label` / `.ezaz-error-msg` | Name entry form |
| `.ezaz-lobby-inner` / `.ezaz-char-badge` / `.ezaz-char-name` / `.ezaz-waiting` | Phone lobby screen |
| `.ezaz-gameover-inner` / `.ezaz-go-rank` / `.ezaz-go-name` / `.ezaz-go-score` | Phone game-over screen |
| `.ezaz-qr-box` / `.ezaz-qr-label` / `.ezaz-qr-url` / `.ezaz-qr-code` | TV scan-to-join panel |
| `.ezaz-slot-card` / `.ezaz-slot-tag` / `.ezaz-slot-name` | TV player slot (uses `.filled` + `--slot-colour`) |
| `.ezaz-score-card` / `.ezaz-score-tag` / `.ezaz-score-val` / `.ezaz-score-rank` | TV end-screen score cards |
| `.ezaz-lb-wrap` / `.ezaz-lb-title` / `.ezaz-lb-row` / `.ezaz-lb-empty` | TV leaderboard |
| `.ezaz-lb-name-input` / `.ezaz-btn-save` | TV leaderboard name entry |
| `.ezaz-hint` | TV hint text |

Design tokens on `:root`: `--ez-teal`, `--ez-yellow`, `--ez-pink`, `--ez-red`, `--ez-gold`, `--ez-bg`, `--ez-surface`, `--ez-border`, `--ez-font`, `--ez-slot-0` through `--ez-slot-3`.

---

## Per-game changes

### Snake Pit Royale

**TV** (`public/games/snake-pit-royale.html`): shared CSS link added; `.store-banner` → `.ezaz-store-banner`; `.btn` updated to `var(--ez-teal)`; bespoke `.join-box`, `.slot-card`, `.lb-title`, `.lb-row`, `.lb-empty`, `.score-card`, `.score-tag`, `.score-val`, `.score-rank`, `.lb-name-input`, `.btn-small`, `.hint` all removed and replaced with `ezaz-*` equivalents in HTML and JS innerHTML strings.

**Phone** (`app/views/snake_pit/join.html.erb`): shared CSS link added; store banner → brand gradient; JOIN button → `.ezaz-btn-primary` (green override); lobby/gameover screens use `ezaz-*` wrappers; BACK TO LOBBY / BACK TO STORE → `.ezaz-btn-outline` (was near-invisible gray).

### Golden Goal

**TV** (`public/games/golden-goal.html`): same treatment as Snake Pit Royale; `.btn` updated to `var(--ez-gold)`; JS `renderLb` and score grid innerHTML strings migrated to `ezaz-*` class names.

**Phone** (`app/views/golden_goal/join.html.erb`): same treatment; JOIN button → `.ezaz-btn-primary` (gold override); store banner link corrected from game gold to brand gradient.

### Dino Jump

**TV** (`public/games/dino-jump.html`): shared CSS link added; `.store-banner` → `.ezaz-store-banner`; start button changed from gray gradient to `var(--ez-yellow)` (was the only gray primary button across all games); QR box, slot cards, leaderboard, score cards migrated to `ezaz-*` classes; `updateSlot` JS updated to use `.filled` class + `--slot-colour` CSS custom property (consistent with the shared slot card pattern); JS innerHTML strings for leaderboard and score grid migrated.

**Phone** (`app/views/dino_jump/join.html.erb`): shared CSS link added; store banner → brand gradient; JOIN button → `.ezaz-btn-primary` (yellow override); lobby/gameover screens use `ezaz-*` wrappers. **Also fixes a pre-existing Phone Contract clause 4 violation**: this page had no EXIT button. Added `.ezaz-exit-btn` and wired the exit handler manually (Dino Jump uses a custom `AzCable` rather than `ArcadeCable`, so `ArcadeCable.attachExit` could not be reused; the 150 ms delay pattern matches).

---

## Before / after highlights

| Surface | Before | After |
|---|---|---|
| Store banner link | Game accent colour (green / gold / yellow per game) | Brand gradient (pink → teal → yellow) on all |
| Snake Pit "BACK TO STORE" | `rgba(255,255,255,0.2)` border, `#aaa` text — near-invisible | Teal border + teal text (`.ezaz-btn-outline`) |
| Golden Goal "BACK TO LOBBY" | Same near-invisible treatment | Same fix |
| Dino Jump start button | `linear-gradient(135deg, #555, #333)` gray | `var(--ez-yellow)` |
| QR join box | Tinted with game accent colour | Always teal (brand-level interaction) |
| Dino Jump phone JOIN page | No EXIT button (Phone Contract clause 4 violation) | EXIT button present and wired |

---

## Docs

- `docs/design-system.md` — usage guide: tokens, component list, HTML snippets, JS patterns for `updateSlot`, `renderLb`, score grid.
- `docs/decisions/011-shared-design-system.md` — ADR capturing the 10 decisions made during this pass (prefix convention, teal QR box, CSS custom property overrides, JS innerHTML requirement, deferred reference-game migration, etc.)

---

## What was not changed

- All ActionCable behaviour is unchanged. Phone Contract clauses 3, 4, 5, 6 are intact for Snake Pit and Golden Goal. Dino Jump clause 4 was missing and is now fixed.
- No gameplay, scoring, or game logic was touched.
- Family Trivia, Spotlight, and Treasure Hunt are not migrated in this pass. They served as the design reference. Migrating them is deferred (noted in ADR 011 decision 10).
- Tests: the Rails test suite (`bin/rails test`, ~439 passing) cannot be run in this remote environment because Bundler gems are not installed in the cloud container. The changes are HTML/CSS only and do not touch any Rails controllers, models, channels, or routing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ25aE78g21x72PUF5721u)_