### PR TITLE
Share design tokens in the reference TV-party games

### DIFF
--- a/app/views/spotlight/show.html.erb
+++ b/app/views/spotlight/show.html.erb
@@ -1,10 +1,15 @@
+<link rel="stylesheet" href="/ez-az-shell.css">
 <style>
   [hidden] { display: none !important; }
 
+  /* Core surface + brand tokens come from the shared shell (ez-az-shell.css).
+     These local aliases keep the game's short names working while pointing at
+     one source of truth. Slot colours (--c1..--c4) and --gold stay
+     game-specific (this game's gold is #ffd700, not the shell's --ez-gold). */
   :root {
     --c1: #ff4757; --c2: #3742fa; --c3: #ffa502; --c4: #2ed573;
-    --bg: #0a0a12; --surface: #13131f; --border: rgba(255,255,255,0.08);
-    --teal: #00ffc8; --gold: #ffd700;
+    --bg: var(--ez-bg); --surface: var(--ez-surface); --border: var(--ez-border);
+    --teal: var(--ez-teal); --gold: #ffd700;
   }
 
   .sp {

--- a/app/views/treasure/show.html.erb
+++ b/app/views/treasure/show.html.erb
@@ -1,10 +1,15 @@
+<link rel="stylesheet" href="/ez-az-shell.css">
 <style>
   [hidden] { display: none !important; }
 
+  /* Core surface + brand tokens come from the shared shell (ez-az-shell.css).
+     These local aliases keep the game's short names working while pointing at
+     one source of truth. Slot colours, card colours and --gold stay
+     game-specific (this game's gold is #ffd700, not the shell's --ez-gold). */
   :root {
     --c1: #ff4757; --c2: #3742fa; --c3: #ffa502; --c4: #2ed573;
-    --bg: #0a0a12; --surface: #13131f; --border: rgba(255,255,255,0.08);
-    --teal: #00ffc8;
+    --bg: var(--ez-bg); --surface: var(--ez-surface); --border: var(--ez-border);
+    --teal: var(--ez-teal);
     --gold: #ffd700;
     --card-red: #ff4757;
     --card-blue: #3742fa;

--- a/app/views/trivia/show.html.erb
+++ b/app/views/trivia/show.html.erb
@@ -1,10 +1,14 @@
+<link rel="stylesheet" href="/ez-az-shell.css">
 <style>
   [hidden] { display: none !important; }
 
+  /* Core surface + brand tokens come from the shared shell (ez-az-shell.css).
+     These local aliases keep the game's short names working while pointing at
+     one source of truth. Slot colours (--c1..--c4) stay game-specific. */
   :root {
     --c1: #ff4757; --c2: #3742fa; --c3: #ffa502; --c4: #2ed573;
-    --bg: #0a0a12; --surface: #13131f; --border: rgba(255,255,255,0.08);
-    --teal: #00ffc8;
+    --bg: var(--ez-bg); --surface: var(--ez-surface); --border: var(--ez-border);
+    --teal: var(--ez-teal);
   }
 
   .tq {


### PR DESCRIPTION
## What this does

Migrates the three reference TV-party games — **Family Trivia**, **Spotlight**, **Treasure Hunt** — onto the shared design system (`public/ez-az-shell.css`, ADR 011) at the level that can be applied **visually neutrally**: the shared design tokens.

> [!IMPORTANT]
> These three games are the visual gold standard the shell was extracted from. Please **compare before/after on each** (`/games/trivia`, `/games/spotlight`, `/games/treasure-hunt`). The change is intended to be pixel-identical; verified in-browser below.

## A key reality check on scope

The migration brief assumed these games are structured like Snake Pit / Golden Goal (a `public/games/*.html` TV file + a per-game `*/join.html.erb` phone page) and would adopt the full set of `.ezaz-*` **component** classes (slot cards, leaderboard rows, score cards, QR box, store-banner strip).

In reality they are different:

- They are **TV-only ERB views** (`app/views/{trivia,spotlight,treasure}/show.html.erb`) rendered in the `tv` layout. Their **phone side is the unified Zone** (`tv_remote/show.html.erb`), not a per-game join page — so there is no per-game join page to migrate, and the Phone-Contract exit button lives in the Zone.
- They use a **broadcast-style fluid layout** (`vw`/`vh`, `clamp()`, system sans-serif, `.tq-*`/`.sp-*`/`.th-*` classes). The shell's `.ezaz-*` components are **arcade-styled** (`Press Start 2P`, fixed px) because they were extracted from Snake Pit / Golden Goal / Dino Jump. The two are different visual registers.
- They have **no `/api/scores` leaderboard** (live session scores only), so the shell's `.ezaz-lb-*` / `.ezaz-score-card` classes have nothing to map to.
- They use an **inline themed logo** in a flex header, not the fixed `.ezaz-store-banner` top strip, and each game's logo gradient is intentionally themed differently (trivia teal/blue/pink, spotlight gold/orange/pink, treasure gold/teal/pink).
- Their gold is `#ffd700`, which differs from the shell's `--ez-gold` `#ffd23b`.

Forcing the `.ezaz-*` **component** classes onto them would visibly change their appearance — which the brief explicitly forbids ("never worse", "don't distort the shell"). ADR 011 decision 10 already documents that these games were the design *reference* and that component migration was deferred as "purely cosmetic" with regression risk. So the honest, faithful migration is at the **token** level, where there is genuine shared source-of-truth overlap.

## What was replaced (per game)

All three (`trivia`, `spotlight`, `treasure` `show.html.erb`):

- **Added** `<link rel="stylesheet" href="/ez-az-shell.css">` so the shared `:root` tokens are available.
- **Replaced** the hardcoded local copies of the core surface/brand tokens with aliases to the shared tokens:
  - `--bg: var(--ez-bg)` · `--surface: var(--ez-surface)` · `--border: var(--ez-border)` · `--teal: var(--ez-teal)`
- **Left bespoke** (intentionally different from the shell, so changing them would alter the look):
  - slot colours `--c1..--c4`
  - Treasure's card colours `--card-red/blue/green/yellow`
  - each game's `--gold` (`#ffd700`)

## Appearance unchanged — verified

The aliased values are identical to what the games hardcoded. Confirmed in a real browser on the Trivia page that the computed tokens still resolve to the original values after linking the shell:

- `--bg` → `#0a0a12`  · `--surface` → `#13131f`  · `--teal` → `#00ffc8`  · `--border` → `rgba(255,255,255,0.08)`
- shell confirmed loaded (`--ez-teal` resolves)

No intentional visual changes. (Only console message on the page is a pre-existing `icon-192.png` 404 from the `tv` layout, unrelated to this change.)

## Not touched

No gameplay, ActionCable channels, scoring, routes, models or controllers. Chrome/CSS only.

## Tests

`bin/rails test` → **439 runs, 1477 assertions, 0 failures, 0 errors, 0 skips** (matches baseline).

## Zone / room views assessment

- **Zone** (`app/views/tv_remote/show.html.erb`): a fully bespoke `.zone-*` layout (system font, `dvh`, safe-area insets) — the phone companion for these broadcast-style games, with its own established component names (per `CLAUDE.md`). It does not match the arcade `.ezaz-*` primitives. **Recommend NOT migrating in this pass** — it would be a redesign, not a neutral migration. Flag for a dedicated follow-up if Jay wants the Zone to consume shell tokens.
- **TV / rooms / room_input views** (`app/views/tv/`, `rooms/`, `room_input/`): none currently reference the shell or its tokens. Same situation — bespoke layouts, no obvious one-line safe link to add. **Recommend leaving for a follow-up.**

If Jay wants these three reference games to actually *render* with the shell's arcade `.ezaz-*` components, that is a deliberate visual redesign (changing fonts, sizing, banner, leaderboard styling) and should be its own card with screenshots — not folded into a "neutral" migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)